### PR TITLE
[fix] #22: support URI with a path

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -28,10 +28,11 @@ class Utils {
     final useSecure = uri.isSecureScheme || forceSecure;
     final httpScheme = useSecure ? 'https' : 'http';
     final wsScheme = useSecure ? 'wss' : 'ws';
+    final pathIterables = [...uri.pathSegments, validate ? 'validate' : 'rtc'];
 
     return uri.replace(
       scheme: validate ? httpScheme : wsScheme,
-      path: validate ? 'validate' : 'rtc',
+      path: pathIterables.join('/'),
       queryParameters: <String, String>{
         'access_token': token,
         if (options != null)


### PR DESCRIPTION
this is basically to support livekit URI with a path like `wss://example.com/path/to/livekit`