### PR TITLE
Use min for width/height to apply constraints

### DIFF
--- a/lib/src/track/options.dart
+++ b/lib/src/track/options.dart
@@ -228,8 +228,8 @@ class VideoParameters {
   // https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
   //
   Map<String, dynamic> toMediaConstraintsMap() => <String, dynamic>{
-        'maxWidth': width,
-        'maxHeight': height,
+        'minWidth': width,
+        'minHeight': height,
         'maxFrameRate': encoding.maxFramerate,
       };
 }


### PR DESCRIPTION
Fixes https://github.com/livekit/client-sdk-flutter/issues/26

Turns out that the underlying flutter webrtc only looks at `minHeight` and `minWidth` for applying constraints, and otherwise defaults to 720p.

That said, the library will pop an OverconstrainedError if the requested constraints are too high (at least on Chrome, Android I think will automatically find the closest supported format, haven't checked on iOS). Might need to find a way to make the available formats visible to the user or handle that ourselves.