### PR TITLE
Type-aware Publication etc (static typing)

### DIFF
--- a/example/lib/widgets/controls.dart
+++ b/example/lib/widgets/controls.dart
@@ -69,8 +69,7 @@ class _ControlsWidgetState extends State<ControlsWidget> {
 
   void _toggleCamera() async {
     //
-    final track =
-        participant.videoTracks.firstOrNull?.track;
+    final track = participant.videoTracks.firstOrNull?.track;
     if (track == null) return;
 
     try {

--- a/example/lib/widgets/controls.dart
+++ b/example/lib/widgets/controls.dart
@@ -70,7 +70,7 @@ class _ControlsWidgetState extends State<ControlsWidget> {
   void _toggleCamera() async {
     //
     final track =
-        participant.videoTracks.firstOrNull?.track as LocalVideoTrack?;
+        participant.videoTracks.firstOrNull?.track;
     if (track == null) return;
 
     try {

--- a/lib/src/participant/local_participant.dart
+++ b/lib/src/participant/local_participant.dart
@@ -241,8 +241,8 @@ class LocalParticipant extends Participant {
       super.videoTracks.cast<LocalTrackPublication<LocalVideoTrack>>();
 
   @override
-  List<LocalTrackPublication> get audioTracks =>
-      super.audioTracks.cast<LocalTrackPublication>();
+  List<LocalTrackPublication<LocalAudioTrack>> get audioTracks =>
+      super.audioTracks.cast<LocalTrackPublication<LocalAudioTrack>>();
 }
 
 extension LocalParticipantTrackSourceExt on LocalParticipant {

--- a/lib/src/participant/local_participant.dart
+++ b/lib/src/participant/local_participant.dart
@@ -75,7 +75,7 @@ class LocalParticipant extends Participant {
     );
     await engine.negotiate();
 
-    final pub = LocalTrackPublication(trackInfo, track, this);
+    final pub = LocalTrackPublication<LocalAudioTrack>(trackInfo, track, this);
     addTrackPublication(pub);
 
     [events, roomEvents].emit(LocalTrackPublishedEvent(
@@ -154,7 +154,7 @@ class LocalParticipant extends Participant {
     );
     await engine.negotiate();
 
-    final pub = LocalTrackPublication(trackInfo, track, this);
+    final pub = LocalTrackPublication<LocalVideoTrack>(trackInfo, track, this);
     addTrackPublication(pub);
 
     [events, roomEvents].emit(LocalTrackPublishedEvent(
@@ -237,8 +237,8 @@ class LocalParticipant extends Participant {
       super.subscribedTracks.cast<LocalTrackPublication>().toList();
 
   @override
-  List<LocalTrackPublication> get videoTracks =>
-      super.videoTracks.cast<LocalTrackPublication>();
+  List<LocalTrackPublication<LocalVideoTrack>> get videoTracks =>
+      super.videoTracks.cast<LocalTrackPublication<LocalVideoTrack>>();
 
   @override
   List<LocalTrackPublication> get audioTracks =>

--- a/lib/src/participant/remote_participant.dart
+++ b/lib/src/participant/remote_participant.dart
@@ -26,12 +26,12 @@ class RemoteParticipant extends Participant {
       super.subscribedTracks.cast<RemoteTrackPublication>().toList();
 
   @override
-  List<RemoteTrackPublication> get videoTracks =>
-      super.videoTracks.cast<RemoteTrackPublication>();
+  List<RemoteTrackPublication<RemoteVideoTrack>> get videoTracks =>
+      super.videoTracks.cast<RemoteTrackPublication<RemoteVideoTrack>>();
 
   @override
-  List<RemoteTrackPublication> get audioTracks =>
-      super.audioTracks.cast<RemoteTrackPublication>();
+  List<RemoteTrackPublication<RemoteAudioTrack>> get audioTracks =>
+      super.audioTracks.cast<RemoteTrackPublication<RemoteAudioTrack>>();
 
   RemoteParticipant(
     this._engine,

--- a/lib/src/participant/remote_participant.dart
+++ b/lib/src/participant/remote_participant.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
+import 'package:livekit_client/livekit_client.dart';
 import 'package:meta/meta.dart';
 
 import '../constants.dart';
@@ -7,9 +8,9 @@ import '../extensions.dart';
 import '../logger.dart';
 import '../managers/event.dart';
 import '../proto/livekit_models.pb.dart' as lk_models;
+import '../publication/remote_track_publication.dart';
 import '../rtc_engine.dart';
 import '../track/remote/audio.dart';
-import '../publication/remote_track_publication.dart';
 import '../track/remote/video.dart';
 import '../track/track.dart';
 import '../types.dart';
@@ -134,7 +135,14 @@ class RemoteParticipant extends Participant {
     for (final trackInfo in info.tracks) {
       RemoteTrackPublication? pub = getTrackPublication(trackInfo.sid);
       if (pub == null) {
-        pub = RemoteTrackPublication(trackInfo, this);
+        final RemoteTrackPublication pub;
+        if (trackInfo.type == lk_models.TrackType.VIDEO) {
+          pub = RemoteTrackPublication<RemoteVideoTrack>(trackInfo, this);
+        } else if (trackInfo.type == lk_models.TrackType.AUDIO) {
+          pub = RemoteTrackPublication<RemoteAudioTrack>(trackInfo, this);
+        } else {
+          throw UnexpectedStateException('Unknown track type');
+        }
         newPubs.add(pub);
         addTrackPublication(pub);
       } else {

--- a/lib/src/publication/local_track_publication.dart
+++ b/lib/src/publication/local_track_publication.dart
@@ -7,11 +7,11 @@ import '../track/local.dart';
 import '../track/track.dart';
 import 'track_publication.dart';
 
-class LocalTrackPublication extends TrackPublication {
+class LocalTrackPublication<T extends LocalTrack> extends TrackPublication {
   final LocalParticipant _participant;
 
   @override
-  covariant LocalTrack? track;
+  covariant T? track;
 
   LocalTrackPublication(
     lk_models.TrackInfo info,

--- a/lib/src/publication/remote_track_publication.dart
+++ b/lib/src/publication/remote_track_publication.dart
@@ -31,9 +31,9 @@ class RendererVisibility {
 
 /// Represents a track publication from a RemoteParticipant. Provides methods to
 /// control if we should subscribe to the track, and its quality (for video).
-class RemoteTrackPublication extends TrackPublication {
+class RemoteTrackPublication<T extends RemoteTrack> extends TrackPublication {
   @override
-  covariant RemoteTrack? track;
+  covariant T? track;
 
   final RemoteParticipant _participant;
   bool _enabled = true;


### PR DESCRIPTION
No casting is required anymore for `TrackPublication.track`

`LocalParticipant.videoTracks` returns `List<LocalTrackPublication<LocalVideoTrack>>`