### PR TITLE
Fix rendering of remote shared screen

### DIFF
--- a/example/lib/widgets/participant.dart
+++ b/example/lib/widgets/participant.dart
@@ -171,10 +171,12 @@ class _RemoteParticipantWidgetState
 
   @override
   VideoTrack? get activeVideoTrack {
-    if (firstVideoPublication?.subscribed == true &&
-        firstVideoPublication?.muted == false &&
-        _visible) {
-      return firstVideoPublication?.track;
+    for (final trackPublication in widget.participant.videoTracks) {
+      print(
+          'video track ${trackPublication.sid} subscribed ${trackPublication.subscribed} muted ${trackPublication.muted}');
+      if (trackPublication.subscribed && !trackPublication.muted) {
+        return trackPublication.track;
+      }
     }
   }
 


### PR DESCRIPTION
Fix activeVideoTrack to return any unmuted stream, not only first one in the list.