### PR TITLE
Fix: mute Remote mute/unmute events

### DIFF
--- a/lib/src/internal/events.dart
+++ b/lib/src/internal/events.dart
@@ -66,13 +66,16 @@ class TrackVisibilityUpdatedEvent with TrackEvent, InternalEvent {
   });
 }
 
+// Used to notify muted state from Track to TrackPublication.
 @internal
-class TrackMuteUpdatedEvent with TrackEvent, InternalEvent {
+class InternalTrackMuteUpdatedEvent with TrackEvent, InternalEvent {
   final Track track;
   final bool muted;
-  const TrackMuteUpdatedEvent({
+  final bool shouldSendSignal;
+  const InternalTrackMuteUpdatedEvent({
     required this.track,
     required this.muted,
+    required this.shouldSendSignal,
   });
 
   @override

--- a/lib/src/publication/remote_track_publication.dart
+++ b/lib/src/publication/remote_track_publication.dart
@@ -93,7 +93,6 @@ class RemoteTrackPublication<T extends RemoteTrack>
   @override
   void updateFromInfo(lk_models.TrackInfo info) {
     super.updateFromInfo(info);
-    updateMuted(info.muted);
     track?.updateMuted(info.muted);
   }
 

--- a/lib/src/publication/track_publication.dart
+++ b/lib/src/publication/track_publication.dart
@@ -1,6 +1,9 @@
+import '../events.dart';
+import '../internal/events.dart';
 import 'package:meta/meta.dart';
 
 import '../extensions.dart';
+import '../logger.dart';
 import '../participant/participant.dart';
 import '../proto/livekit_models.pb.dart' as lk_models;
 import '../support/disposable.dart';
@@ -26,9 +29,7 @@ abstract class TrackPublication<T extends Track> extends Disposable {
   /// The [Participant] this publication belongs to.
   abstract final Participant participant;
 
-  // metadata-muted
-  bool _muted = false;
-  bool get muted => _muted;
+  bool get muted => track?.muted ?? false;
 
   bool simulcasted = false;
   TrackDimension? dimension;
@@ -64,9 +65,6 @@ abstract class TrackPublication<T extends Track> extends Disposable {
   bool operator ==(Object other) =>
       other is TrackPublication && sid == other.sid;
 
-  @internal
-  void updateMuted(bool muted) => _muted = muted;
-
   // Update track to new value, dispose previous if exists.
   // Returns true if value has changed.
   // Intended for internal use only.
@@ -76,6 +74,30 @@ abstract class TrackPublication<T extends Track> extends Disposable {
     // dispose previous track (if exists)
     await _track?.dispose();
     _track = newValue;
+
+    if (newValue != null) {
+      // listen for Track's muted events
+      final listener = newValue.createListener()
+        ..on<InternalTrackMuteUpdatedEvent>(
+            (event) => _onTrackMuteUpdatedEvent(event));
+      // dispose listener when the track is disposed
+      newValue.onDispose(() => listener.dispose());
+    }
+
     return true;
+  }
+
+  void _onTrackMuteUpdatedEvent(InternalTrackMuteUpdatedEvent event) {
+    // send signal to server (if mute initiated by local user)
+      if (event.shouldSendSignal) {
+      logger.fine(
+          '${this} Sending mute signal... sid:${sid}, muted:${event.muted}');
+      participant.room.engine.signalClient.sendMuteTrack(sid, event.muted);
+    }
+    // emit events
+    final newEvent = event.muted
+        ? TrackMutedEvent(participant: participant, track: this)
+        : TrackUnmutedEvent(participant: participant, track: this);
+    [participant.events, participant.room.events].emit(newEvent);
   }
 }

--- a/lib/src/publication/track_publication.dart
+++ b/lib/src/publication/track_publication.dart
@@ -89,7 +89,7 @@ abstract class TrackPublication<T extends Track> extends Disposable {
 
   void _onTrackMuteUpdatedEvent(InternalTrackMuteUpdatedEvent event) {
     // send signal to server (if mute initiated by local user)
-      if (event.shouldSendSignal) {
+    if (event.shouldSendSignal) {
       logger.fine(
           '${this} Sending mute signal... sid:${sid}, muted:${event.muted}');
       participant.room.engine.signalClient.sendMuteTrack(sid, event.muted);

--- a/lib/src/track/local.dart
+++ b/lib/src/track/local.dart
@@ -4,7 +4,6 @@ import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 import 'package:meta/meta.dart';
 
 import '../exceptions.dart';
-import '../internal/events.dart';
 import '../logger.dart';
 import '../proto/livekit_models.pb.dart' as lk_models;
 import '../types.dart';
@@ -41,8 +40,7 @@ abstract class LocalTrack extends Track {
     if (!Platform.isWindows) {
       await stop();
     }
-    updateMuted(true);
-    events.emit(TrackMuteUpdatedEvent(track: this, muted: muted));
+    updateMuted(true, shouldSendSignal: true);
     return true;
   }
 
@@ -54,8 +52,7 @@ abstract class LocalTrack extends Track {
       await restartTrack();
     }
     await enable();
-    updateMuted(false);
-    events.emit(TrackMuteUpdatedEvent(track: this, muted: muted));
+    updateMuted(false, shouldSendSignal: true);
     return true;
   }
 

--- a/lib/src/track/track.dart
+++ b/lib/src/track/track.dart
@@ -139,7 +139,15 @@ abstract class Track extends DisposableChangeNotifier
   }
 
   @internal
-  void updateMuted(bool muted) => _muted = muted;
+  void updateMuted(bool muted, {bool shouldSendSignal = false}) {
+    if (_muted == muted) return;
+    _muted = muted;
+    events.emit(InternalTrackMuteUpdatedEvent(
+      track: this,
+      muted: muted,
+      shouldSendSignal: shouldSendSignal,
+    ));
+  }
 
   @internal
   void updateMediaStreamAndTrack(


### PR DESCRIPTION
LK-370
Issue https://github.com/livekit/client-sdk-flutter/issues/52

`RemoteTrackPublication.updateFromInfo` was not triggering events... 😞

**Local**
`LocalTrackPublication.mute()` or `LocalTrack.mute()` -> `Track.updateMuted(shouldSendSignal:true)` -> `TrackPublication._onTrackMuteUpdatedEvent()` -> `TrackMutedEvent/TrackUnmutedEvent` emitted.

**Remote**
`RemoteTrackPublication.updateFromInfo` -> `Track.updateMuted(shouldSendSignal:false)` -> `TrackPublication._onTrackMuteUpdatedEvent()` -> `TrackMutedEvent/TrackUnmutedEvent` emitted.
