### PR TITLE
Subscription permission API

### DIFF
--- a/example/lib/exts.dart
+++ b/example/lib/exts.dart
@@ -135,4 +135,24 @@ extension LKExampleExt on BuildContext {
           ],
         ),
       );
+
+
+  Future<bool?> showSubscribePermissionDialog() => showDialog<bool>(
+        context: this,
+        builder: (ctx) => AlertDialog(
+          title: const Text('Allow subscription'),
+          content: const Text('Allow all participants to subscribe tracks published by local participant?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('NO'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('YES'),
+            ),
+          ],
+        ),
+      );
+
 }

--- a/example/lib/exts.dart
+++ b/example/lib/exts.dart
@@ -136,12 +136,12 @@ extension LKExampleExt on BuildContext {
         ),
       );
 
-
   Future<bool?> showSubscribePermissionDialog() => showDialog<bool>(
         context: this,
         builder: (ctx) => AlertDialog(
           title: const Text('Allow subscription'),
-          content: const Text('Allow all participants to subscribe tracks published by local participant?'),
+          content: const Text(
+              'Allow all participants to subscribe tracks published by local participant?'),
           actions: [
             TextButton(
               onPressed: () => Navigator.pop(ctx, false),
@@ -154,5 +154,4 @@ extension LKExampleExt on BuildContext {
           ],
         ),
       );
-
 }

--- a/example/lib/widgets/controls.dart
+++ b/example/lib/widgets/controls.dart
@@ -136,6 +136,19 @@ class _ControlsWidgetState extends State<ControlsWidget> {
     }
   }
 
+  void _onTapUpdateSubscribePermission() async {
+    final result = await context.showSubscribePermissionDialog();
+    if (result != null) {
+      try {
+        widget.room.localParticipant?.setTrackSubscriptionPermissions(
+          allParticipantsAllowed: result,
+        );
+      } catch (error) {
+        await context.showErrorDialog(error);
+      }
+    }
+  }
+
   void _onTapSendData() async {
     final result = await context.showSendDataDialog();
     if (result == true) {
@@ -219,6 +232,11 @@ class _ControlsWidgetState extends State<ControlsWidget> {
             onPressed: _onTapReconnect,
             icon: const Icon(EvaIcons.refresh),
             tooltip: 're-connect',
+          ),
+          IconButton(
+            onPressed: _onTapUpdateSubscribePermission,
+            icon: const Icon(EvaIcons.settings2),
+            tooltip: 'Subscribe permission',
           ),
         ],
       ),

--- a/example/lib/widgets/participant.dart
+++ b/example/lib/widgets/participant.dart
@@ -192,13 +192,13 @@ class _RemoteParticipantWidgetState
             if (firstVideoPublication != null)
               RemoteTrackPublicationMenuWidget(
                 pub: firstVideoPublication!,
-                icon: EvaIcons.videoOutline,
+                icon: EvaIcons.video,
               ),
             // Menu for RemoteTrackPublication<RemoteAudioTrack>
             if (firstAudioPublication != null)
               RemoteTrackPublicationMenuWidget(
                 pub: firstAudioPublication!,
-                icon: EvaIcons.volumeUpOutline,
+                icon: EvaIcons.volumeUp,
               ),
           ],
         ),
@@ -218,23 +218,27 @@ class RemoteTrackPublicationMenuWidget extends StatelessWidget {
   Widget build(BuildContext context) => Material(
         color: Colors.black.withOpacity(0.3),
         child: PopupMenuButton<Function>(
-          icon: Icon(icon),
+          tooltip: 'Subscribe menu',
+          icon: Icon(icon,
+              color: {
+                TrackSubscriptionState.notAllowed: Colors.red,
+                TrackSubscriptionState.unsubscribed: Colors.grey,
+                TrackSubscriptionState.subscribed: Colors.green,
+              }[pub.subscriptionState()]),
           onSelected: (value) => value(),
-          itemBuilder: (BuildContext context) {
-            return <PopupMenuEntry<Function>>[
-              // Subscribe/Unsubscribe
-              if (pub.subscribed == false)
-                PopupMenuItem(
-                  child: const Text('Subscribe'),
-                  value: () => pub.subscribed = true,
-                )
-              else if (pub.subscribed == true)
-                PopupMenuItem(
-                  child: const Text('Un-subscribe'),
-                  value: () => pub.subscribed = false,
-                ),
-            ];
-          },
+          itemBuilder: (BuildContext context) => <PopupMenuEntry<Function>>[
+            // Subscribe/Unsubscribe
+            if (pub.subscribed == false)
+              PopupMenuItem(
+                child: const Text('Subscribe'),
+                value: () => pub.subscribed = true,
+              )
+            else if (pub.subscribed == true)
+              PopupMenuItem(
+                child: const Text('Un-subscribe'),
+                value: () => pub.subscribed = false,
+              ),
+          ],
         ),
       );
 }

--- a/example/lib/widgets/participant.dart
+++ b/example/lib/widgets/participant.dart
@@ -224,19 +224,19 @@ class RemoteTrackPublicationMenuWidget extends StatelessWidget {
                 TrackSubscriptionState.notAllowed: Colors.red,
                 TrackSubscriptionState.unsubscribed: Colors.grey,
                 TrackSubscriptionState.subscribed: Colors.green,
-              }[pub.subscriptionState()]),
+              }[pub.subscriptionState]),
           onSelected: (value) => value(),
           itemBuilder: (BuildContext context) => <PopupMenuEntry<Function>>[
             // Subscribe/Unsubscribe
             if (pub.subscribed == false)
               PopupMenuItem(
                 child: const Text('Subscribe'),
-                value: () => pub.subscribed = true,
+                value: () => pub.subscribe(),
               )
             else if (pub.subscribed == true)
               PopupMenuItem(
                 child: const Text('Un-subscribe'),
-                value: () => pub.subscribed = false,
+                value: () => pub.unsubscribe(),
               ),
           ],
         ),

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -428,6 +428,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.livekit.example.flutter.macos;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
@@ -555,6 +556,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.livekit.example.flutter.macos;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -571,11 +573,13 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = J48VV6BZV9;
+				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.livekit.example.flutter.macos;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};

--- a/lib/src/core/engine.dart
+++ b/lib/src/core/engine.dart
@@ -622,7 +622,7 @@ class Engine extends Disposable with EventsEmittable<EngineEvent> {
     // relay to Room
     ..on<SignalSubscribedQualityUpdatedEvent>((event) => events.emit(event))
     // relay to Room
-    ..on<SubscriptionPermissionUpdateEvent>((event) => events.emit(event))
+    ..on<SignalSubscriptionPermissionUpdateEvent>((event) => events.emit(event))
     ..on<SignalLeaveEvent>((event) async {
       if (connectionState == ConnectionState.reconnecting) {
         logger.warning('Received leave signal while engine is reconnecting.');

--- a/lib/src/core/engine.dart
+++ b/lib/src/core/engine.dart
@@ -621,6 +621,8 @@ class Engine extends Disposable with EventsEmittable<EngineEvent> {
     ..on<SignalStreamStateUpdatedEvent>((event) => events.emit(event))
     // relay to Room
     ..on<SignalSubscribedQualityUpdatedEvent>((event) => events.emit(event))
+    // relay to Room
+    ..on<SubscriptionPermissionUpdateEvent>((event) => events.emit(event))
     ..on<SignalLeaveEvent>((event) async {
       if (connectionState == ConnectionState.reconnecting) {
         logger.warning('Received leave signal while engine is reconnecting.');

--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -192,6 +192,11 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
       publication.updatePublishingLayers(event.updates);
     })
     ..on<SignalSubscriptionPermissionUpdateEvent>((event) {
+      logger.fine('SignalSubscriptionPermissionUpdateEvent '
+          'participantSid:${event.participantSid} '
+          'trackSid:${event.trackSid} '
+          'allowed:${event.allowed}');
+
       // find participant
       final participant = _participants[event.participantSid];
       if (participant == null) {

--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -203,7 +203,7 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
         return;
       }
       //
-      if (publication.updateAllowedToSubscribe(event.allowed)) {
+      if (publication.updateSubscriptionAllowed(event.allowed)) {
         [participant.events, events]
             .emit(TrackSubscriptionPermissionChangedEvent(
           participant: participant,

--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -203,14 +203,7 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
         return;
       }
       //
-      if (publication.updateSubscriptionAllowed(event.allowed)) {
-        [participant.events, events]
-            .emit(TrackSubscriptionPermissionChangedEvent(
-          participant: participant,
-          trackPublication: publication,
-          state: publication.subscriptionState(),
-        ));
-      }
+      publication.updateSubscriptionAllowed(event.allowed);
     })
     ..on<EngineTrackAddedEvent>((event) async {
       logger.fine('EngineTrackAddedEvent trackSid:${event.track.id}');

--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -191,7 +191,7 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
       }
       publication.updatePublishingLayers(event.updates);
     })
-    ..on<SignalSubscriptionPermissionUpdateEvent>((event) {
+    ..on<SignalSubscriptionPermissionUpdateEvent>((event) async {
       logger.fine('SignalSubscriptionPermissionUpdateEvent '
           'participantSid:${event.participantSid} '
           'trackSid:${event.trackSid} '
@@ -208,7 +208,7 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
         return;
       }
       //
-      publication.updateSubscriptionAllowed(event.allowed);
+      await publication.updateSubscriptionAllowed(event.allowed);
     })
     ..on<EngineTrackAddedEvent>((event) async {
       logger.fine('EngineTrackAddedEvent trackSid:${event.track.id}');

--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -191,6 +191,27 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
       }
       publication.updatePublishingLayers(event.updates);
     })
+    ..on<SubscriptionPermissionUpdateEvent>((event) {
+      // find participant
+      final participant = _participants[event.participantSid];
+      if (participant == null) {
+        return;
+      }
+      // find track
+      final publication = participant.trackPublications[event.trackSid];
+      if (publication == null) {
+        return;
+      }
+      //
+      if (publication.updateAllowedToSubscribe(event.allowed)) {
+        [participant.events, events]
+            .emit(TrackSubscriptionPermissionChangedEvent(
+          participant: participant,
+          trackPublication: publication,
+          state: publication.subscriptionState(),
+        ));
+      }
+    })
     ..on<EngineTrackAddedEvent>((event) async {
       logger.fine('EngineTrackAddedEvent trackSid:${event.track.id}');
 

--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -191,7 +191,7 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
       }
       publication.updatePublishingLayers(event.updates);
     })
-    ..on<SubscriptionPermissionUpdateEvent>((event) {
+    ..on<SignalSubscriptionPermissionUpdateEvent>((event) {
       // find participant
       final participant = _participants[event.participantSid];
       if (participant == null) {

--- a/lib/src/core/signal_client.dart
+++ b/lib/src/core/signal_client.dart
@@ -187,7 +187,7 @@ class SignalClient extends Disposable with EventsEmittable<SignalEvent> {
         ));
         break;
       case lk_rtc.SignalResponse_Message.subscriptionPermissionUpdate:
-        events.emit(SubscriptionPermissionUpdateEvent(
+        events.emit(SignalSubscriptionPermissionUpdateEvent(
           participantSid: msg.subscriptionPermissionUpdate.participantSid,
           trackSid: msg.subscriptionPermissionUpdate.trackSid,
           allowed: msg.subscriptionPermissionUpdate.allowed,

--- a/lib/src/core/signal_client.dart
+++ b/lib/src/core/signal_client.dart
@@ -303,6 +303,17 @@ extension SignalClientRequests on SignalClient {
         ),
       ));
 
+  void sendUpdateSubscriptionPermissions({
+    required bool allParticipants,
+    required List<lk_rtc.TrackPermission> trackPermissions,
+  }) =>
+      _sendRequest(lk_rtc.SignalRequest(
+        subscriptionPermissions: lk_rtc.UpdateSubscriptionPermissions(
+          allParticipants: allParticipants,
+          trackPermissions: trackPermissions,
+        ),
+      ));
+
   void sendLeave() => _sendRequest(lk_rtc.SignalRequest(
         leave: lk_rtc.LeaveRequest(),
       ));

--- a/lib/src/core/signal_client.dart
+++ b/lib/src/core/signal_client.dart
@@ -186,6 +186,13 @@ class SignalClient extends Disposable with EventsEmittable<SignalEvent> {
           updates: msg.subscribedQualityUpdate.subscribedQualities,
         ));
         break;
+      case lk_rtc.SignalResponse_Message.subscriptionPermissionUpdate:
+        events.emit(SubscriptionPermissionUpdateEvent(
+          participantSid: msg.subscriptionPermissionUpdate.participantSid,
+          trackSid: msg.subscriptionPermissionUpdate.trackSid,
+          allowed: msg.subscriptionPermissionUpdate.allowed,
+        ));
+        break;
       default:
         logger.warning('skipping unsupported signal message');
     }

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -244,3 +244,18 @@ class SpeakingChangedEvent with ParticipantEvent {
     required this.speaking,
   });
 }
+
+/// One of subscribed tracks have changed its permissions for the current
+/// participant. If permission was revoked, then the track will no longer
+/// be subscribed. If permission was granted, a TrackSubscribed event will
+/// be emitted.
+class TrackSubscriptionPermissionChangedEvent with RoomEvent, ParticipantEvent {
+  final Participant participant;
+  final RemoteTrackPublication trackPublication;
+  final TrackSubscriptionState state;
+  const TrackSubscriptionPermissionChangedEvent({
+    required this.participant,
+    required this.trackPublication,
+    required this.state,
+  });
+}

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -140,3 +140,11 @@ extension VideoQualityExt on lk_models.VideoQuality {
         lk_models.VideoQuality.LOW: 'q',
       }[this]!;
 }
+
+extension ParticipantTrackPermissionExt on ParticipantTrackPermission {
+  lk_rtc.TrackPermission toPBType() => lk_rtc.TrackPermission(
+        participantSid: participantSid,
+        allTracks: allowedTrackSids == null,
+        trackSids: allowedTrackSids ?? [],
+      );
+}

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -144,7 +144,7 @@ extension VideoQualityExt on lk_models.VideoQuality {
 extension ParticipantTrackPermissionExt on ParticipantTrackPermission {
   lk_rtc.TrackPermission toPBType() => lk_rtc.TrackPermission(
         participantSid: participantSid,
-        allTracks: allowedTrackSids == null,
-        trackSids: allowedTrackSids ?? [],
+        allTracks: allTracksAllowed,
+        trackSids: allowedTrackSids,
       );
 }

--- a/lib/src/internal/events.dart
+++ b/lib/src/internal/events.dart
@@ -208,12 +208,12 @@ class SignalSubscribedQualityUpdatedEvent
 }
 
 @internal
-class SubscriptionPermissionUpdateEvent
+class SignalSubscriptionPermissionUpdateEvent
     with SignalEvent, EngineEvent, InternalEvent {
   final String participantSid;
   final String trackSid;
   final bool allowed;
-  const SubscriptionPermissionUpdateEvent({
+  const SignalSubscriptionPermissionUpdateEvent({
     required this.participantSid,
     required this.trackSid,
     required this.allowed,

--- a/lib/src/internal/events.dart
+++ b/lib/src/internal/events.dart
@@ -207,6 +207,18 @@ class SignalSubscribedQualityUpdatedEvent
   });
 }
 
+@internal
+class SubscriptionPermissionUpdateEvent with SignalEvent, EngineEvent, InternalEvent {
+  final String participantSid;
+  final String trackSid;
+  final bool allowed;
+  const SubscriptionPermissionUpdateEvent({
+    required this.participantSid,
+    required this.trackSid,
+    required this.allowed,
+  });
+}
+
 // ----------------------------------------------------------------------
 // Engine events
 // ----------------------------------------------------------------------

--- a/lib/src/internal/events.dart
+++ b/lib/src/internal/events.dart
@@ -208,7 +208,8 @@ class SignalSubscribedQualityUpdatedEvent
 }
 
 @internal
-class SubscriptionPermissionUpdateEvent with SignalEvent, EngineEvent, InternalEvent {
+class SubscriptionPermissionUpdateEvent
+    with SignalEvent, EngineEvent, InternalEvent {
   final String participantSid;
   final String trackSid;
   final bool allowed;

--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -312,14 +312,15 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
   /// who is able to subscribe at a participant and track level.
   ///
   /// Note: if access is given at a track-level (i.e. both [allParticipantsAllowed] and
-  /// [allTracksAllowed] are false), any newer published tracks
+  /// [ParticipantTrackPermission.allTracksAllowed] are false), any newer published tracks
   /// will not grant permissions to any participants and will require a subsequent
   /// permissions update to allow subscription.
   ///
-  /// @param allParticipantsAllowed Allows all participants to subscribe all tracks.
-  /// Takes precedence over [[participantTrackPermissions]] if set to true.
+  /// [allParticipantsAllowed] Allows all participants to subscribe all tracks.
+  /// Takes precedence over [trackPermissions] if set to true.
   /// By default this is set to true.
-  /// @param participantTrackPermissions Full list of individual permissions per
+  ///
+  /// [trackPermissions] Full list of individual permissions per
   /// participant/track. Any omitted participants will not receive any permissions.
 
   void setTrackSubscriptionPermissions({

--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -3,6 +3,7 @@ import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 import 'package:meta/meta.dart';
 
 import '../core/room.dart';
+import '../core/signal_client.dart';
 import '../events.dart';
 import '../exceptions.dart';
 import '../extensions.dart';
@@ -304,4 +305,29 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
       }
     }
   }
+
+  /// Control who can subscribe to LocalParticipant's published tracks.
+  ///
+  /// By default, all participants can subscribe. This allows fine-grained control over
+  /// who is able to subscribe at a participant and track level.
+  ///
+  /// Note: if access is given at a track-level (i.e. both [allParticipantsAllowed] and
+  /// [allTracksAllowed] are false), any newer published tracks
+  /// will not grant permissions to any participants and will require a subsequent
+  /// permissions update to allow subscription.
+  ///
+  /// @param allParticipantsAllowed Allows all participants to subscribe all tracks.
+  /// Takes precedence over [[participantTrackPermissions]] if set to true.
+  /// By default this is set to true.
+  /// @param participantTrackPermissions Full list of individual permissions per
+  /// participant/track. Any omitted participants will not receive any permissions.
+
+  void setTrackSubscriptionPermissions({
+    required bool allParticipantsAllowed,
+    List<ParticipantTrackPermission> trackPermissions = const [],
+  }) =>
+      room.engine.signalClient.sendUpdateSubscriptionPermissions(
+        allParticipants: allParticipantsAllowed,
+        trackPermissions: trackPermissions.map((e) => e.toPBType()).toList(),
+      );
 }

--- a/lib/src/publication/remote.dart
+++ b/lib/src/publication/remote.dart
@@ -279,7 +279,7 @@ class RemoteTrackPublication<T extends RemoteTrack>
   }
 
   TrackSubscriptionState subscriptionState() {
-    if (!subscribed || !super.subscribed) {
+    if (!super.subscribed) {
       return TrackSubscriptionState.unsubscribed;
     } else if (!_subscriptionAllowed) {
       return TrackSubscriptionState.notAllowed;

--- a/lib/src/publication/remote.dart
+++ b/lib/src/publication/remote.dart
@@ -277,11 +277,9 @@ class RemoteTrackPublication<T extends RemoteTrack>
   }
 
   TrackSubscriptionState subscriptionState() {
-    if (!super.subscribed) {
-      return TrackSubscriptionState.unsubscribed;
-    } else if (!_subscriptionAllowed) {
-      return TrackSubscriptionState.notAllowed;
-    }
-    return TrackSubscriptionState.subscribed;
+    if (!_subscriptionAllowed) return TrackSubscriptionState.notAllowed;
+    return super.subscribed
+        ? TrackSubscriptionState.subscribed
+        : TrackSubscriptionState.unsubscribed;
   }
 }

--- a/lib/src/publication/remote.dart
+++ b/lib/src/publication/remote.dart
@@ -258,6 +258,15 @@ class RemoteTrackPublication<T extends RemoteTrack>
     return true;
   }
 
+  @override
+  bool get subscribed {
+    // always return false when subscription is not allowed
+    if (!_subscriptionAllowed) {
+      return false;
+    }
+    return super.subscribed;
+  }
+
   TrackSubscriptionState subscriptionState() {
     if (!subscribed || !super.subscribed) {
       return TrackSubscriptionState.unsubscribed;

--- a/lib/src/publication/remote.dart
+++ b/lib/src/publication/remote.dart
@@ -43,7 +43,8 @@ class RemoteTrackPublication<T extends RemoteTrack>
   bool _metadataMuted = false;
 
   // allowed to subscribe
-  bool _allowedToSubscribe = true;
+  bool _subscriptionAllowed = true;
+  bool get subscriptionAllowed => _subscriptionAllowed;
 
   @internal
   Future<void> updateStreamState(StreamState streamState) async {
@@ -251,16 +252,16 @@ class RemoteTrackPublication<T extends RemoteTrack>
 
   @internal
   // Update internal var and return true if changed
-  bool updateAllowedToSubscribe(bool allowed) {
-    if (_allowedToSubscribe == allowed) return false;
-    _allowedToSubscribe = allowed;
+  bool updateSubscriptionAllowed(bool allowed) {
+    if (_subscriptionAllowed == allowed) return false;
+    _subscriptionAllowed = allowed;
     return true;
   }
 
   TrackSubscriptionState subscriptionState() {
     if (!subscribed || !super.subscribed) {
       return TrackSubscriptionState.unsubscribed;
-    } else if (!_allowedToSubscribe) {
+    } else if (!_subscriptionAllowed) {
       return TrackSubscriptionState.notAllowed;
     }
     return TrackSubscriptionState.subscribed;

--- a/lib/src/publication/remote.dart
+++ b/lib/src/publication/remote.dart
@@ -255,6 +255,17 @@ class RemoteTrackPublication<T extends RemoteTrack>
   bool updateSubscriptionAllowed(bool allowed) {
     if (_subscriptionAllowed == allowed) return false;
     _subscriptionAllowed = allowed;
+
+    // emit events
+    [
+      participant.events,
+      participant.room.events,
+    ].emit(TrackSubscriptionPermissionChangedEvent(
+      participant: participant,
+      trackPublication: this,
+      state: subscriptionState(),
+    ));
+
     return true;
   }
 

--- a/lib/src/publication/remote.dart
+++ b/lib/src/publication/remote.dart
@@ -42,6 +42,9 @@ class RemoteTrackPublication<T extends RemoteTrack>
   // latest TrackInfo
   bool _metadataMuted = false;
 
+  // allowed to subscribe
+  bool _allowedToSubscribe = true;
+
   @internal
   Future<void> updateStreamState(StreamState streamState) async {
     // return if no change
@@ -244,5 +247,22 @@ class RemoteTrackPublication<T extends RemoteTrack>
       settings.quality = _videoQuality;
     }
     participant.room.engine.signalClient.sendUpdateTrackSettings(settings);
+  }
+
+  @internal
+  // Update internal var and return true if changed
+  bool updateAllowedToSubscribe(bool allowed) {
+    if (_allowedToSubscribe == allowed) return false;
+    _allowedToSubscribe = allowed;
+    return true;
+  }
+
+  TrackSubscriptionState subscriptionState() {
+    if (!subscribed || !super.subscribed) {
+      return TrackSubscriptionState.unsubscribed;
+    } else if (!_allowedToSubscribe) {
+      return TrackSubscriptionState.notAllowed;
+    }
+    return TrackSubscriptionState.subscribed;
   }
 }

--- a/lib/src/publication/remote.dart
+++ b/lib/src/publication/remote.dart
@@ -272,9 +272,7 @@ class RemoteTrackPublication<T extends RemoteTrack>
   @override
   bool get subscribed {
     // always return false when subscription is not allowed
-    if (!_subscriptionAllowed) {
-      return false;
-    }
+    if (!_subscriptionAllowed) return false;
     return super.subscribed;
   }
 

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -171,13 +171,16 @@ class ParticipantTrackPermission {
   /// The participant id this permission applies to.
   final String participantSid;
 
-  // The list of track ids that the target participant can subscribe to.
-  // When unset, it'll allow all tracks to be subscribed by the participant.
-  // When empty, this participant is disallowed from subscribing to any tracks.
-  final List<String>? allowedTrackSids;
+  /// If set to true, the target participant can subscribe to all tracks from the local participant.
+  /// Takes precedence over [allowedTrackSids].
+  final bool allTracksAllowed;
+
+  /// The list of track ids that the target participant can subscribe to.
+  final List<String> allowedTrackSids;
 
   const ParticipantTrackPermission(
     this.participantSid,
+    this.allTracksAllowed,
     this.allowedTrackSids,
   );
 }

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -45,6 +45,12 @@ enum TrackSource {
   screenShareAudio,
 }
 
+enum TrackSubscriptionState {
+  unsubscribed,
+  subscribed,
+  notAllowed,
+}
+
 /// The state of track data stream.
 /// This is controlled by server to optimize bandwidth.
 enum StreamState {
@@ -158,4 +164,20 @@ class VideoDimensions {
         width ?? this.width,
         height ?? this.height,
       );
+}
+
+@immutable
+class ParticipantTrackPermission {
+  /// The participant id this permission applies to.
+  final String participantSid;
+
+  // The list of track ids that the target participant can subscribe to.
+  // When unset, it'll allow all tracks to be subscribed by the participant.
+  // When empty, this participant is disallowed from subscribing to any tracks.
+  final List<String>? allowedTrackSids;
+
+  const ParticipantTrackPermission(
+    this.participantSid,
+    this.allowedTrackSids,
+  );
 }


### PR DESCRIPTION
Still needs more polishing but would appreciate if oniichans could take a look 😁

TODO
- JS is emitting `TrackEvent.Ended`
- [x] Android's `ParticipantTrackPermission` has `allTracksAllowed`
- [ ] Emit `TrackSubscribed` / `TrackUnubscribed` when permission resumed.

**Needs testing**