### PR TITLE
internet permission for example's Manifest

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
   <uses-permission android:name="android.permission.WAKE_LOCK" />
   <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+  <uses-permission android:name="android.permission.INTERNET" />
   <application
         android:label="LiveKit Example"
         android:icon="@mipmap/livekit_ic_launcher">


### PR DESCRIPTION
if you build an APK using the example, it won't connect to the server, it's missing the INTERNET permission on AndroidManifest.xml