### PR TITLE
Fix crash on android in portrait

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -230,10 +230,12 @@ class Utils {
         return;
       }
       final size = dimensions.max();
+      final encodingSize = e.dimensions.max();
       final rid = videoRids[i];
+
       result.add(e.encoding.toRTCRtpEncoding(
         rid: rid,
-        scaleResolutionDownBy: size / e.dimensions.height,
+        scaleResolutionDownBy: size / encodingSize,
       ));
     });
     return result;


### PR DESCRIPTION
encoding scale calculation was using the wrong side, and ended up getting the wrong numbers (e.g. odd numbers which crash android).