### PR TITLE
Use ParticipantTracks for UpdateSubscription

### DIFF
--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -1,5 +1,3 @@
-import 'dart:collection';
-
 import 'package:collection/collection.dart';
 
 import '../core/signal_client.dart';

--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -461,11 +461,14 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
   Future<void> _sendSyncState() async {
     final connectOptions = this.connectOptions ?? const ConnectOptions();
     final sendUnSub = connectOptions.autoSubscribe;
+    final participantTracks =
+        participants.values.map((e) => e.participantTracks());
     engine.sendSyncState(
       subscription: lk_rtc.UpdateSubscription(
+        participantTracks: participantTracks,
+        // Deprecated
+        trackSids: participantTracks.map((e) => e.trackSids).flattened,
         subscribe: !sendUnSub,
-        participantTracks:
-            participants.values.map((e) => e.participantTracks()),
       ),
       publishTracks: localParticipant?.publishedTracksInfo(),
     );

--- a/lib/src/publication/remote.dart
+++ b/lib/src/publication/remote.dart
@@ -265,8 +265,13 @@ class RemoteTrackPublication<T extends RemoteTrack>
 
   void _sendUpdateSubscription({required bool subscribed}) {
     logger.fine('Sending update subscription... ${sid} ${subscribed}');
-    final subscription = lk_rtc.UpdateSubscription(
+    final participantTrack = lk_models.ParticipantTracks(
+      participantSid: participant.sid,
       trackSids: [sid],
+    );
+    final subscription = lk_rtc.UpdateSubscription(
+      participantTracks: [participantTrack],
+      trackSids: [sid], // Deprecated
       subscribe: subscribed,
     );
     participant.room.engine.signalClient.sendUpdateSubscription(subscription);


### PR DESCRIPTION
`sendSyncState` is already using participantTracks, just for `sendUpdateSubscription`