### PR TITLE
Ensure even video dimensions

### DIFF
--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -159,6 +159,9 @@ class VideoDimensions {
   /// Returns the larger value
   int max() => math.max(width, height);
 
+  /// Returns the smaller value
+  int min() => math.min(width, height);
+
   VideoDimensions copyWith({
     int? width,
     int? height,


### PR DESCRIPTION
Looks like there's a separate issue where the dimensions we're using for scale calculation may not match the capture format the camera is using, so the even dimensions checking we're using here may still be incorrect.