### PR TITLE
Simplify internal events

### DIFF
--- a/lib/src/core/engine.dart
+++ b/lib/src/core/engine.dart
@@ -559,14 +559,12 @@ class Engine extends Disposable with EventsEmittable<EngineEvent> {
       }
 
       // Relay to Room
-      events.emit(event);
+      events.emit(EngineJoinResponseEvent(response: event.response));
     })
     ..on<SignalConnectionStateUpdatedEvent>((event) async {
       if (event.newState == ConnectionState.disconnected) {
         await _onDisconnected(DisconnectReason.signal);
       }
-      // Relay to Room
-      events.emit(event);
     })
     ..on<SignalOfferEvent>((event) async {
       if (subscriber == null) {
@@ -611,20 +609,6 @@ class Engine extends Disposable with EventsEmittable<EngineEvent> {
         await publisher!.addIceCandidate(event.candidate);
       }
     })
-    // relay to Room
-    ..on<SignalParticipantUpdateEvent>((event) => events.emit(event))
-    // relay to Room
-    ..on<SignalSpeakersChangedEvent>((event) => events.emit(event))
-    // relay to Room
-    ..on<SignalConnectionQualityUpdateEvent>((event) => events.emit(event))
-    // relay to Room
-    ..on<SignalStreamStateUpdatedEvent>((event) => events.emit(event))
-    // relay to Room
-    ..on<SignalSubscribedQualityUpdatedEvent>((event) => events.emit(event))
-    // relay to Room
-    ..on<SignalSubscriptionPermissionUpdateEvent>((event) => events.emit(event))
-    // relay to Room
-    ..on<SignalRoomUpdateEvent>((event) => events.emit(event))
     ..on<SignalTokenUpdatedEvent>((event) {
       logger.fine('Server refreshed the token');
       token = event.token;
@@ -636,12 +620,7 @@ class Engine extends Disposable with EventsEmittable<EngineEvent> {
         return;
       }
       await cleanUp();
-    })
-    ..on<SignalMuteTrackEvent>(
-        (event) => events.emit(EngineRemoteMuteChangedEvent(
-              sid: event.sid,
-              muted: event.muted,
-            )));
+    });
 }
 
 extension EnginePrivateMethods on Engine {

--- a/lib/src/core/engine.dart
+++ b/lib/src/core/engine.dart
@@ -557,9 +557,6 @@ class Engine extends Disposable with EventsEmittable<EngineEvent> {
         // for subscriberPrimary, we negotiate when necessary (lazy)
         await negotiate();
       }
-
-      // Relay to Room
-      events.emit(EngineJoinResponseEvent(response: event.response));
     })
     ..on<SignalConnectionStateUpdatedEvent>((event) async {
       if (event.newState == ConnectionState.disconnected) {

--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -73,6 +73,8 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
   final Engine engine;
   // suppport for multiple event listeners
   late final EventsListener<EngineEvent> _engineListener;
+  //
+  late final EventsListener<SignalEvent> _signalListener;
 
   Room({
     ConnectOptions? connectOptions,
@@ -82,7 +84,10 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
         _roomOptions = roomOptions,
         engine = engine ?? Engine() {
     _engineListener = this.engine.createListener();
-    _setUpListeners();
+    _setUpEngineListeners();
+
+    _signalListener = this.engine.signalClient.createListener();
+    _setUpSignalListeners();
 
     // Any event emitted will trigger ChangeNotifier
     events.listen((event) {
@@ -97,7 +102,9 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
       await events.dispose();
       // dispose local participant
       await localParticipant?.dispose();
-      // dispose all listeners for RTCEngine
+      // dispose all listeners for SignalClient
+      await _signalListener.dispose();
+      // dispose all listeners for Engine
       await _engineListener.dispose();
       // dispose the engine
       await this.engine.dispose();
@@ -117,69 +124,15 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
     return engine.connect(url, token, this.connectOptions);
   }
 
-  void _setUpListeners() => _engineListener
-    ..on<EngineConnectionStateUpdatedEvent>((event) async {
-      if (event.didReconnect) {
-        events.emit(const RoomReconnectedEvent());
-        await _handlePostReconnect(false);
-      } else if (event.newState == ConnectionState.reconnecting) {
-        events.emit(const RoomReconnectingEvent());
-      } else if (event.newState == ConnectionState.disconnected) {
-        await _cleanUp();
-        events.emit(const RoomDisconnectedEvent());
-      }
-      // always notify ChangeNotifier
-      notifyListeners();
-    })
-    ..on<SignalConnectionStateUpdatedEvent>((event) {
-      // during reconnection, need to send sync state upon signal connection.
-      if (event.didReconnect) {
-        logger.fine('Sending syncState');
-        _sendSyncState();
-      }
-    })
-    ..on<SignalJoinResponseEvent>((event) {
-      _sid = event.response.room.sid;
-      _name = event.response.room.name;
-      _metadata = event.response.room.metadata;
-      _serverVersion = event.response.serverVersion;
-      _serverRegion = event.response.serverRegion;
-
-      logger.fine('[Engine] Received JoinResponse, '
-          'serverVersion: ${event.response.serverVersion}');
-
-      _localParticipant = LocalParticipant(
-        room: this,
-        info: event.response.participant,
-      );
-
-      for (final info in event.response.otherParticipants) {
-        logger.fine('Creating RemoteParticipant: ${info.sid}(${info.identity}) '
-            'tracks:${info.tracks.map((e) => e.sid)}');
-        _getOrCreateRemoteParticipant(info.sid, info);
-      }
-
-      logger.fine('Room Connect completed');
-    })
+  void _setUpSignalListeners() => _signalListener
     ..on<SignalParticipantUpdateEvent>(
         (event) => _onParticipantUpdateEvent(event.participants))
-    ..on<EngineActiveSpeakersUpdateEvent>(
-        (event) => _onEngineActiveSpeakersUpdateEvent(event.speakers))
     ..on<SignalSpeakersChangedEvent>(
         (event) => _onSignalSpeakersChangedEvent(event.speakers))
     ..on<SignalConnectionQualityUpdateEvent>(
         (event) => _onSignalConnectionQualityUpdateEvent(event.updates))
     ..on<SignalStreamStateUpdatedEvent>(
         (event) => _onSignalStreamStateUpdateEvent(event.updates))
-    ..on<EngineDataPacketReceivedEvent>(_onDataMessageEvent)
-    ..on<EngineRemoteMuteChangedEvent>((event) async {
-      final publication = localParticipant?.trackPublications[event.sid];
-      if (event.muted) {
-        await publication?.mute();
-      } else {
-        await publication?.unmute();
-      }
-    })
     ..on<SignalSubscribedQualityUpdatedEvent>((event) {
       // Signal for Dynacast
       final options = roomOptions ?? const RoomOptions();
@@ -221,6 +174,62 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
       _metadata = event.room.metadata;
       events.emit(RoomMetadataChangedEvent(metadata: event.room.metadata));
     })
+    ..on<SignalConnectionStateUpdatedEvent>((event) {
+      // during reconnection, need to send sync state upon signal connection.
+      if (event.didReconnect) {
+        logger.fine('Sending syncState');
+        _sendSyncState();
+      }
+    })
+    ..on<SignalRemoteMuteTrackEvent>((event) async {
+      final publication = localParticipant?.trackPublications[event.sid];
+      if (event.muted) {
+        await publication?.mute();
+      } else {
+        await publication?.unmute();
+      }
+    });
+
+  void _setUpEngineListeners() => _engineListener
+    ..on<EngineConnectionStateUpdatedEvent>((event) async {
+      if (event.didReconnect) {
+        events.emit(const RoomReconnectedEvent());
+        await _handlePostReconnect(false);
+      } else if (event.newState == ConnectionState.reconnecting) {
+        events.emit(const RoomReconnectingEvent());
+      } else if (event.newState == ConnectionState.disconnected) {
+        await _cleanUp();
+        events.emit(const RoomDisconnectedEvent());
+      }
+      // always notify ChangeNotifier
+      notifyListeners();
+    })
+    ..on<EngineJoinResponseEvent>((event) {
+      _sid = event.response.room.sid;
+      _name = event.response.room.name;
+      _metadata = event.response.room.metadata;
+      _serverVersion = event.response.serverVersion;
+      _serverRegion = event.response.serverRegion;
+
+      logger.fine('[Engine] Received JoinResponse, '
+          'serverVersion: ${event.response.serverVersion}');
+
+      _localParticipant = LocalParticipant(
+        room: this,
+        info: event.response.participant,
+      );
+
+      for (final info in event.response.otherParticipants) {
+        logger.fine('Creating RemoteParticipant: ${info.sid}(${info.identity}) '
+            'tracks:${info.tracks.map((e) => e.sid)}');
+        _getOrCreateRemoteParticipant(info.sid, info);
+      }
+
+      logger.fine('Room Connect completed');
+    })
+    ..on<EngineActiveSpeakersUpdateEvent>(
+        (event) => _onEngineActiveSpeakersUpdateEvent(event.speakers))
+    ..on<EngineDataPacketReceivedEvent>(_onDataMessageEvent)
     ..on<EngineTrackAddedEvent>((event) async {
       logger.fine('EngineTrackAddedEvent trackSid:${event.track.id}');
 

--- a/lib/src/core/signal_client.dart
+++ b/lib/src/core/signal_client.dart
@@ -186,7 +186,7 @@ class SignalClient extends Disposable with EventsEmittable<SignalEvent> {
         events.emit(SignalLeaveEvent(canReconnect: msg.leave.canReconnect));
         break;
       case lk_rtc.SignalResponse_Message.mute:
-        events.emit(SignalMuteTrackEvent(
+        events.emit(SignalRemoteMuteTrackEvent(
           sid: msg.mute.sid,
           muted: msg.mute.muted,
         ));

--- a/lib/src/internal/events.dart
+++ b/lib/src/internal/events.dart
@@ -82,7 +82,7 @@ class InternalTrackMuteUpdatedEvent with TrackEvent, InternalEvent {
 
 @internal
 // Received a JoinResponse from the server.
-class SignalJoinResponseEvent with SignalEvent, EngineEvent, InternalEvent {
+class SignalJoinResponseEvent with SignalEvent, InternalEvent {
   final lk_rtc.JoinResponse response;
   const SignalJoinResponseEvent({
     required this.response,
@@ -91,7 +91,7 @@ class SignalJoinResponseEvent with SignalEvent, EngineEvent, InternalEvent {
 
 /// Base class for a ConnectionStateUpdated event
 @internal
-abstract class ConnectionStateUpdatedEvent with EngineEvent, InternalEvent {
+abstract class ConnectionStateUpdatedEvent with InternalEvent {
   final ConnectionState newState;
   final ConnectionState oldState;
   final bool didReconnect;
@@ -168,8 +168,7 @@ class SignalTrickleEvent with SignalEvent, InternalEvent {
 
 @internal
 // relayed by Engine
-class SignalParticipantUpdateEvent
-    with SignalEvent, EngineEvent, InternalEvent {
+class SignalParticipantUpdateEvent with SignalEvent, InternalEvent {
   final List<lk_models.ParticipantInfo> participants;
   const SignalParticipantUpdateEvent({
     required this.participants,
@@ -177,8 +176,7 @@ class SignalParticipantUpdateEvent
 }
 
 @internal
-class SignalConnectionQualityUpdateEvent
-    with SignalEvent, EngineEvent, InternalEvent {
+class SignalConnectionQualityUpdateEvent with SignalEvent, InternalEvent {
   final List<lk_rtc.ConnectionQualityInfo> updates;
   const SignalConnectionQualityUpdateEvent({
     required this.updates,
@@ -197,7 +195,7 @@ class SignalLocalTrackPublishedEvent with SignalEvent, InternalEvent {
 }
 
 @internal
-class SignalRoomUpdateEvent with SignalEvent, EngineEvent, InternalEvent {
+class SignalRoomUpdateEvent with SignalEvent, InternalEvent {
   final lk_models.Room room;
 
   const SignalRoomUpdateEvent({required this.room});
@@ -206,7 +204,7 @@ class SignalRoomUpdateEvent with SignalEvent, EngineEvent, InternalEvent {
 @internal
 // Speaker update received through websocket
 // relayed by Engine
-class SignalSpeakersChangedEvent with SignalEvent, EngineEvent, InternalEvent {
+class SignalSpeakersChangedEvent with SignalEvent, InternalEvent {
   final List<lk_models.SpeakerInfo> speakers;
 
   const SignalSpeakersChangedEvent({
@@ -232,18 +230,17 @@ class SignalLeaveEvent with SignalEvent, InternalEvent {
 }
 
 @internal
-class SignalMuteTrackEvent with SignalEvent, InternalEvent {
+class SignalRemoteMuteTrackEvent with SignalEvent, InternalEvent {
   final String sid;
   final bool muted;
-  const SignalMuteTrackEvent({
+  const SignalRemoteMuteTrackEvent({
     required this.sid,
     required this.muted,
   });
 }
 
 @internal
-class SignalStreamStateUpdatedEvent
-    with SignalEvent, EngineEvent, InternalEvent {
+class SignalStreamStateUpdatedEvent with SignalEvent, InternalEvent {
   final List<lk_rtc.StreamStateInfo> updates;
   const SignalStreamStateUpdatedEvent({
     required this.updates,
@@ -251,8 +248,7 @@ class SignalStreamStateUpdatedEvent
 }
 
 @internal
-class SignalSubscribedQualityUpdatedEvent
-    with SignalEvent, EngineEvent, InternalEvent {
+class SignalSubscribedQualityUpdatedEvent with SignalEvent, InternalEvent {
   final String trackSid;
   final List<lk_rtc.SubscribedQuality> updates;
   const SignalSubscribedQualityUpdatedEvent({
@@ -262,8 +258,7 @@ class SignalSubscribedQualityUpdatedEvent
 }
 
 @internal
-class SignalSubscriptionPermissionUpdateEvent
-    with SignalEvent, EngineEvent, InternalEvent {
+class SignalSubscriptionPermissionUpdateEvent with SignalEvent, InternalEvent {
   final String participantSid;
   final String trackSid;
   final bool allowed;
@@ -287,6 +282,15 @@ class SignalTokenUpdatedEvent with SignalEvent, InternalEvent {
 // ----------------------------------------------------------------------
 
 @internal
+// Received a JoinResponse from the server.
+class EngineJoinResponseEvent with EngineEvent, InternalEvent {
+  final lk_rtc.JoinResponse response;
+  const EngineJoinResponseEvent({
+    required this.response,
+  });
+}
+
+@internal
 class EngineTrackAddedEvent with EngineEvent, InternalEvent {
   final rtc.MediaStreamTrack track;
   final rtc.MediaStream stream;
@@ -305,16 +309,6 @@ class EngineDataPacketReceivedEvent with EngineEvent, InternalEvent {
   const EngineDataPacketReceivedEvent({
     required this.packet,
     required this.kind,
-  });
-}
-
-@internal
-class EngineRemoteMuteChangedEvent with EngineEvent, InternalEvent {
-  final String sid;
-  final bool muted;
-  const EngineRemoteMuteChangedEvent({
-    required this.sid,
-    required this.muted,
   });
 }
 

--- a/lib/src/internal/events.dart
+++ b/lib/src/internal/events.dart
@@ -282,15 +282,6 @@ class SignalTokenUpdatedEvent with SignalEvent, InternalEvent {
 // ----------------------------------------------------------------------
 
 @internal
-// Received a JoinResponse from the server.
-class EngineJoinResponseEvent with EngineEvent, InternalEvent {
-  final lk_rtc.JoinResponse response;
-  const EngineJoinResponseEvent({
-    required this.response,
-  });
-}
-
-@internal
 class EngineTrackAddedEvent with EngineEvent, InternalEvent {
   final rtc.MediaStreamTrack track;
   final rtc.MediaStream stream;


### PR DESCRIPTION
- Remove redundant internal event
- `Room` also directly listens to `SignalEvents` instead of `Engine` relaying them.
