### PR TITLE
There is a bug in defaultValue in String.fromEnvironment, so replace the code.

### DIFF
--- a/example/lib/pages/connect.dart
+++ b/example/lib/pages/connect.dart
@@ -48,12 +48,12 @@ class _ConnectPageState extends State<ConnectPage> {
   // Read saved URL and Token
   Future<void> _readPrefs() async {
     final prefs = await SharedPreferences.getInstance();
-
-    _uriCtrl.text = String.fromEnvironment('URL',
-        defaultValue: prefs.getString(_storeKeyUri) ?? '');
-    _tokenCtrl.text = String.fromEnvironment('TOKEN',
-        defaultValue: prefs.getString(_storeKeyToken) ?? '');
-
+    _uriCtrl.text = const bool.hasEnvironment('URL')
+        ? const String.fromEnvironment('URL')
+        : prefs.getString(_storeKeyUri) ?? '';
+    _tokenCtrl.text = const bool.hasEnvironment('TOKEN')
+        ? const String.fromEnvironment('TOKEN')
+        : prefs.getString(_storeKeyToken) ?? '';
     setState(() {
       _simulcast = prefs.getBool(_storeKeySimulcast) ?? true;
       _adaptiveStream = prefs.getBool(_storeKeyAdaptiveStream) ?? true;


### PR DESCRIPTION
@hiroshihorie There should be no problem in submitting the code yesterday, but it seems that `String.fromEnvironment` has a bug. After setting defaultValue, the value of ENV cannot be taken out, so I have submitted the replacement code after the test is correct.

```dart
/// set URL from ENV, url1  is '' or stored value
final url1 = String.fromEnvironment('URL',  defaultValue: prefs.getString(_storeKeyUri) ?? '');
```

change to:
```dart
/// This will work fine
final url1 = const bool.hasEnvironment('URL')
        ? const String.fromEnvironment('URL')
        : prefs.getString(_storeKeyUri) ?? '';
```

So I made a new patch and it shouldn't go wrong this time. :)