### PR TITLE
bump version for flutter_webrtc.

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -176,7 +176,7 @@ packages:
       name: flutter_webrtc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.7"
+    version: "0.8.9"
   google_fonts:
     dependency: "direct main"
     description:
@@ -510,7 +510,7 @@ packages:
       name: webrtc_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   win32:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -218,7 +218,7 @@ packages:
       name: flutter_webrtc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.7"
+    version: "0.8.9"
   glob:
     dependency: transitive
     description:
@@ -496,7 +496,7 @@ packages:
       name: webrtc_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   uuid: ^3.0.6
   synchronized: ^3.0.0+2
   protobuf: ^2.0.1
-  flutter_webrtc: ^0.8.7
+  flutter_webrtc: ^0.8.9
   dart_webrtc: ^1.0.6
   device_info_plus: ^3.2.3
 


### PR DESCRIPTION
Some fixes in this PR:
* Fixed random crash when connecting or disconnecting room under windows
* Fixed the bug that the microphone could not be started normally under Windows.
* Other fixes.

Will close related issues:
close https://github.com/livekit/client-sdk-flutter/issues/121
close https://github.com/livekit/client-sdk-flutter/issues/64