### PR TITLE
fix: camera release.

### DIFF
--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - FlutterMacOS
   - flutter_webrtc (0.7.1):
     - FlutterMacOS
-    - WebRTC-SDK (= 97.4692.05)
+    - WebRTC-SDK (= 97.4692.06)
   - FlutterMacOS (1.0.0)
   - livekit_client (1.0.0):
     - FlutterMacOS
@@ -12,7 +12,7 @@ PODS:
     - FlutterMacOS
   - shared_preferences_macos (0.0.1):
     - FlutterMacOS
-  - WebRTC-SDK (97.4692.05)
+  - WebRTC-SDK (97.4692.06)
 
 DEPENDENCIES:
   - device_info_plus_macos (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus_macos/macos`)
@@ -42,12 +42,12 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   device_info_plus_macos: 1ad388a1ef433505c4038e7dd9605aadd1e2e9c7
-  flutter_webrtc: 37c4efd66d9d306878c1323d5ac5a1d10c748b3a
+  flutter_webrtc: a019f551482678a0341c79deacbf8d14ab241ceb
   FlutterMacOS: 57701585bf7de1b3fc2bb61f6378d73bbdea8424
   livekit_client: 7479527f38e9c4a4dc2d3c58f99ab0dd531d24d6
   path_provider_macos: 3c0c3b4b0d4a76d2bf989a913c2de869c5641a19
   shared_preferences_macos: a64dc611287ed6cbe28fd1297898db1336975727
-  WebRTC-SDK: a6ee40bda0e3f7dba057907c3897374005c5715b
+  WebRTC-SDK: eca7a6620a3897801207803672b3d036fb40b9d5
 
 PODFILE CHECKSUM: 6eac6b3292e5142cfc23bdeb71848a40ec51c14c
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -176,7 +176,7 @@ packages:
       name: flutter_webrtc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.10"
+    version: "0.8.12"
   google_fonts:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   uuid: ^3.0.6
   synchronized: ^3.0.0+2
   protobuf: ^2.0.1
-  flutter_webrtc: ^0.8.11
+  flutter_webrtc: ^0.8.12
   dart_webrtc: ^1.0.6
   device_info_plus: ^3.2.3
 


### PR DESCRIPTION
fix: macOS cameraLED stays active after stopping a video track

related issue: https://github.com/flutter-webrtc/flutter-webrtc/issues/1000
patch: https://github.com/flutter-webrtc/flutter-webrtc/pull/1002/files