### PR TITLE
Downgrade version settings to support flutter 2.8.0+

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       name: device_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.3"
+    version: "3.2.4"
   device_info_plus_linux:
     dependency: transitive
     description:
@@ -183,7 +183,7 @@ packages:
       name: google_fonts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.2"
+    version: "2.1.0"
   http:
     dependency: transitive
     description:
@@ -197,7 +197,7 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   intl:
     dependency: "direct main"
     description:
@@ -288,7 +288,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.10"
+    version: "2.0.11"
   path_provider_android:
     dependency: transitive
     description:
@@ -309,7 +309,7 @@ packages:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.6"
+    version: "2.1.7"
   path_provider_macos:
     dependency: transitive
     description:
@@ -330,14 +330,14 @@ packages:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.6"
+    version: "2.0.7"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "4.4.0"
   platform:
     dependency: transitive
     description:
@@ -365,14 +365,14 @@ packages:
       name: protobuf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   provider:
     dependency: "direct main"
     description:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.2"
+    version: "6.0.3"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -489,7 +489,7 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.0"
   uuid:
     dependency: transitive
     description:
@@ -517,7 +517,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.5.2"
   xdg_directories:
     dependency: transitive
     description:
@@ -531,7 +531,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.4.1"
+    version: "5.3.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
-  flutter: ">=2.10.0-0"
+  dart: ">=2.17.0-0 <3.0.0"
+  flutter: ">=2.8.1"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 version: 1.0.0
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -15,7 +15,7 @@ dependencies:
   flutter_background: ^1.1.0
   provider: ^6.0.1
   logging: ^1.0.1
-  shared_preferences: ^2.0.11
+  shared_preferences: ^2.0.7
 
   google_fonts: ^2.1.0
   eva_icons_flutter: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.1
 homepage: https://livekit.io
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
   flutter: ">=1.17.0"
 
 dependencies:
@@ -13,14 +13,14 @@ dependencies:
     sdk: flutter
   flutter:
     sdk: flutter
-  async: ^2.8.2
-  collection: ^1.16.0
+  async: ^2.6.1
+  collection: ^1.15.0
   fixnum: ^1.0.1
-  meta: ^1.7.0
-  http: ^0.13.4
+  meta: ^1.3.0
+  http: ^0.13.3
   logging: ^1.0.2
   uuid: ^3.0.6
-  synchronized: ^3.0.0+2
+  synchronized: ^3.0.0
   protobuf: ^2.0.1
   flutter_webrtc: ^0.8.12
   dart_webrtc: ^1.0.6


### PR DESCRIPTION
Since the SDK uses the `Enum.name` feature, it is only downgraded to dart 2.15.0, and the corresponding flutter version is 2.8.x
Compilation tests passed in `flutter 2.8.1` and `3.0.2`.