### PR TITLE
chore: update deps

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       name: device_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.4"
+    version: "4.0.1"
   device_info_plus_linux:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: device_info_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.1"
   eva_icons_flutter:
     dependency: "direct main"
     description:
@@ -119,7 +119,7 @@ packages:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "2.0.1"
   file:
     dependency: transitive
     description:
@@ -152,14 +152,14 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   flutter_svg:
     dependency: "direct main"
     description:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.1.1+1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -176,14 +176,14 @@ packages:
       name: flutter_webrtc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.12"
+    version: "0.9.0"
   google_fonts:
     dependency: "direct main"
     description:
       name: google_fonts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "3.0.1"
   http:
     dependency: transitive
     description:
@@ -218,7 +218,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   livekit_client:
     dependency: "direct main"
     description:
@@ -295,14 +295,14 @@ packages:
       name: path_provider_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.14"
+    version: "2.0.16"
   path_provider_ios:
     dependency: transitive
     description:
       name: path_provider_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.10"
   path_provider_linux:
     dependency: transitive
     description:
@@ -330,14 +330,14 @@ packages:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.7"
+    version: "2.1.0"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.4.0"
+    version: "5.0.0"
   platform:
     dependency: transitive
     description:
@@ -489,7 +489,7 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   uuid:
     dependency: transitive
     description:
@@ -517,7 +517,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.2"
+    version: "2.7.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -531,7 +531,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.3.1"
+    version: "6.1.0"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
-  flutter: ">=2.8.1"
+  dart: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,13 +13,13 @@ dependencies:
 
   intl: ^0.17.0
   flutter_background: ^1.1.0
-  provider: ^6.0.1
-  logging: ^1.0.1
-  shared_preferences: ^2.0.7
+  provider: ^6.0.3
+  logging: ^1.0.2
+  shared_preferences: ^2.0.15
 
-  google_fonts: ^2.1.0
-  eva_icons_flutter: ^3.0.0
-  flutter_svg: ^1.0.0
+  google_fonts: ^3.0.1
+  eva_icons_flutter: ^3.1.0
+  flutter_svg: ^1.1.1+1
 
   livekit_client:
     path: ../
@@ -30,7 +30,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
 
 # The following section is specific to Flutter.
 flutter:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "40.0.0"
+    version: "43.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.3.1"
   args:
     dependency: transitive
     description:
@@ -56,7 +56,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.3.0"
+    version: "8.4.0"
   characters:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   crypto:
     dependency: transitive
     description:
@@ -126,7 +126,7 @@ packages:
       name: device_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.3"
+    version: "4.0.1"
   device_info_plus_linux:
     dependency: transitive
     description:
@@ -161,7 +161,7 @@ packages:
       name: device_info_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.1"
   fake_async:
     dependency: transitive
     description:
@@ -175,7 +175,7 @@ packages:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "2.0.1"
   file:
     dependency: transitive
     description:
@@ -218,14 +218,14 @@ packages:
       name: flutter_webrtc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.10"
+    version: "0.9.0"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.0"
   http:
     dependency: "direct main"
     description:
@@ -239,7 +239,7 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   import_sorter:
     dependency: "direct dev"
     description:
@@ -302,7 +302,7 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.0"
   path:
     dependency: transitive
     description:
@@ -316,28 +316,28 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.10"
+    version: "2.0.11"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.14"
+    version: "2.0.16"
   path_provider_ios:
     dependency: transitive
     description:
       name: path_provider_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.10"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.6"
+    version: "2.1.7"
   path_provider_macos:
     dependency: transitive
     description:
@@ -358,7 +358,7 @@ packages:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.6"
+    version: "2.1.0"
   platform:
     dependency: transitive
     description:
@@ -386,7 +386,7 @@ packages:
       name: protobuf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   pub_semver:
     dependency: transitive
     description:
@@ -503,7 +503,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.7.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -520,4 +520,4 @@ packages:
     version: "3.1.1"
 sdks:
   dart: ">=2.17.0 <3.0.0"
-  flutter: ">=2.8.1"
+  flutter: ">=3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,18 +13,18 @@ dependencies:
     sdk: flutter
   flutter:
     sdk: flutter
-  async: ^2.6.1
-  collection: ^1.15.0
+  async: ^2.8.2
+  collection: ^1.16.0
   fixnum: ^1.0.1
-  meta: ^1.3.0
-  http: ^0.13.3
+  meta: ^1.7.0
+  http: ^0.13.4
   logging: ^1.0.2
   uuid: ^3.0.6
-  synchronized: ^3.0.0
-  protobuf: ^2.0.1
-  flutter_webrtc: ^0.8.12
+  synchronized: ^3.0.0+2
+  protobuf: ^2.1.0
+  flutter_webrtc: ^0.9.0
   dart_webrtc: ^1.0.6
-  device_info_plus: ^3.2.3
+  device_info_plus: ^4.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The deps are getting a little bit out of date, so I updated them. Test and example App work fine.
This includes WebRTC 0.9.0.
For example I am seeing some problems like this:
`Because every version of livekit_client from git depends on device_info_plus ^3.2.3 which depends on device_info_plus_windows ^2.1.1, every version of livekit_client from git requires device_info_plus_windows ^2.1.1.
And because device_info_plus_windows >=1.0.0-nullsafety.0 <3.0.0 depends on ffi ^1.0.0, every version of livekit_client from git requires ffi ^1.0.0.
And because file_picker >=5.0.0 depends on win32 ^2.7.0 which depends on ffi ^2.0.0, livekit_client from git is incompatible with file_picker >=5.0.0.
l`