### PR TITLE
Fixed track not being correctly passed to localParticipant in FastConnectOptions.

### DIFF
--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -151,23 +151,32 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
 
         var audio = options.microphone;
         if (audio.enabled != null && audio.enabled == true) {
-          _localParticipant!.setMicrophoneEnabled(true);
-        } else if (audio.track != null) {
-          _localParticipant!.publishAudioTrack(audio.track as LocalAudioTrack);
+          if (audio.track != null) {
+            _localParticipant!
+                .publishAudioTrack(audio.track as LocalAudioTrack);
+          } else {
+            _localParticipant!.setMicrophoneEnabled(true);
+          }
         }
 
         var video = options.camera;
         if (video.enabled != null && video.enabled == true) {
-          _localParticipant!.setCameraEnabled(true);
-        } else if (video.track != null) {
-          _localParticipant!.publishVideoTrack(video.track as LocalVideoTrack);
+          if (video.track != null) {
+            _localParticipant!
+                .publishVideoTrack(video.track as LocalVideoTrack);
+          } else {
+            _localParticipant!.setCameraEnabled(true);
+          }
         }
 
         var screen = options.screen;
         if (screen.enabled != null && screen.enabled == true) {
-          _localParticipant!.setScreenShareEnabled(true);
-        } else if (screen.track != null) {
-          _localParticipant!.publishVideoTrack(screen.track as LocalVideoTrack);
+          if (screen.track != null) {
+            _localParticipant!
+                .publishVideoTrack(screen.track as LocalVideoTrack);
+          } else {
+            _localParticipant!.setScreenShareEnabled(true);
+          }
         }
       }
 


### PR DESCRIPTION
Fixed track not being correctly passed to localParticipant in FastConnectOptions, causing the camera to apply twice and not be released.

close https://github.com/livekit/client-sdk-flutter/issues/178.
