### PR TITLE
fix: Correctly throws final error when connection fails.

### DIFF
--- a/lib/src/core/signal_client.dart
+++ b/lib/src/core/signal_client.dart
@@ -110,8 +110,9 @@ class SignalClient extends Disposable with EventsEmittable<SignalEvent> {
           finalError = ConnectException(validateResponse.body);
         }
       } catch (error) {
-        finalError = ConnectException(
-            'Unable to get socketError reason from validateUri: $error');
+        if (socketError.runtimeType != error.runtimeType) {
+          finalError = error;
+        }
       } finally {
         _updateConnectionState(ConnectionState.disconnected);
         throw finalError;

--- a/lib/src/core/signal_client.dart
+++ b/lib/src/core/signal_client.dart
@@ -90,6 +90,7 @@ class SignalClient extends Disposable with EventsEmittable<SignalEvent> {
       _updateConnectionState(ConnectionState.connected);
     } catch (socketError) {
       // Attempt Validation
+      var finalError = socketError;
       try {
         // Skip validation if reconnect mode
         if (reconnect) rethrow;
@@ -106,17 +107,13 @@ class SignalClient extends Disposable with EventsEmittable<SignalEvent> {
 
         final validateResponse = await http.get(validateUri);
         if (validateResponse.statusCode != 200) {
-          throw ConnectException(validateResponse.body);
+          finalError = ConnectException(validateResponse.body);
         }
-        throw ConnectException();
       } catch (error) {
-        // Pass it up if it's already a `ConnectError`
-        if (error is ConnectException) rethrow;
-        // HTTP doesn't work either
-        throw ConnectException();
+        finalError = error;
       } finally {
         _updateConnectionState(ConnectionState.disconnected);
-        rethrow;
+        throw finalError;
       }
     }
   }

--- a/lib/src/core/signal_client.dart
+++ b/lib/src/core/signal_client.dart
@@ -110,7 +110,8 @@ class SignalClient extends Disposable with EventsEmittable<SignalEvent> {
           finalError = ConnectException(validateResponse.body);
         }
       } catch (error) {
-        finalError = error;
+        finalError = ConnectException(
+            'Unable to get socketError reason from validateUri: $error');
       } finally {
         _updateConnectionState(ConnectionState.disconnected);
         throw finalError;

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -4,7 +4,7 @@ abstract class LiveKitException implements Exception {
   const LiveKitException._(this.message);
 
   @override
-  String toString() => 'LiveKit Exception $runtimeType $message';
+  String toString() => 'LiveKit Exception: [$runtimeType] $message';
 }
 
 /// An exception occured while attempting to connect.


### PR DESCRIPTION
Use the error from validate url as the last exception for connection failure.