### PR TITLE
fix: Fix renderer issue for Safari/Firefox.

### DIFF
--- a/lib/src/support/platform.dart
+++ b/lib/src/support/platform.dart
@@ -12,6 +12,8 @@ bool lkPlatformIs(PlatformType type) => lkPlatform() == type;
 @internal
 bool lkPlatformIsTest() => Platform.environment.containsKey('FLUTTER_TEST');
 
+BrowserType lkBrowser() => lkBrowserImplementation();
+
 enum PlatformType {
   web,
   windows,
@@ -20,4 +22,13 @@ enum PlatformType {
   android,
   fuchsia,
   iOS,
+}
+
+enum BrowserType {
+  chrome,
+  firefox,
+  safari,
+  internetExplorer,
+  wkWebView,
+  unknown,
 }

--- a/lib/src/support/platform/io.dart
+++ b/lib/src/support/platform/io.dart
@@ -11,3 +11,7 @@ PlatformType lkPlatformImplementation() {
   if (Platform.isAndroid) return PlatformType.android;
   throw UnsupportedError('Unknown Platform');
 }
+
+BrowserType lkBrowserImplementation() {
+  return BrowserType.unknown;
+}

--- a/lib/src/support/platform/web.dart
+++ b/lib/src/support/platform/web.dart
@@ -1,3 +1,14 @@
 import '../platform.dart';
 
+import 'package:platform_detect/platform_detect.dart';
+
 PlatformType lkPlatformImplementation() => PlatformType.web;
+
+BrowserType lkBrowserImplementation() {
+  if (browser.isChrome) return BrowserType.chrome;
+  if (browser.isFirefox) return BrowserType.firefox;
+  if (browser.isSafari) return BrowserType.safari;
+  if (browser.isInternetExplorer) return BrowserType.internetExplorer;
+  if (browser.isWKWebView) return BrowserType.wkWebView;
+  return BrowserType.unknown;
+}

--- a/lib/src/widgets/video_track_renderer.dart
+++ b/lib/src/widgets/video_track_renderer.dart
@@ -87,10 +87,9 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
       })();
     }
 
-    if ([BrowserType.safari, BrowserType.firefox].contains(lkBrowser())) {
-      (() async {
-        _renderer.srcObject = widget.track.mediaStream;
-      })();
+    if ([BrowserType.safari, BrowserType.firefox].contains(lkBrowser()) &&
+        oldWidget.key != widget.key) {
+      _renderer.srcObject = widget.track.mediaStream;
     }
   }
 

--- a/lib/src/widgets/video_track_renderer.dart
+++ b/lib/src/widgets/video_track_renderer.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
+import 'package:platform_detect/platform_detect.dart';
 
 import '../events.dart';
 import '../extensions.dart';
@@ -78,13 +79,16 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
   @override
   void didUpdateWidget(covariant VideoTrackRenderer oldWidget) {
     super.didUpdateWidget(oldWidget);
-    //
     if (widget.track != oldWidget.track) {
       oldWidget.track.removeViewKey(_internalKey);
       _internalKey = widget.track.addViewKey();
-      // TODO: re-attach only if needed
       (() async {
         await _attach();
+      })();
+    }
+    if (browser.isSafari || browser.isFirefox) {
+      (() async {
+        _renderer.srcObject = widget.track.mediaStream;
       })();
     }
   }

--- a/lib/src/widgets/video_track_renderer.dart
+++ b/lib/src/widgets/video_track_renderer.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
-import 'package:platform_detect/platform_detect.dart';
+import 'package:livekit_client/src/support/platform.dart';
 
 import '../events.dart';
 import '../extensions.dart';
@@ -86,7 +86,8 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
         await _attach();
       })();
     }
-    if (browser.isSafari || browser.isFirefox) {
+
+    if ([BrowserType.safari, BrowserType.firefox].contains(lkBrowser())) {
       (() async {
         _renderer.srcObject = widget.track.mediaStream;
       })();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   device_info_plus: ^8.0.0
   webrtc_interface: 1.0.11
   dart_webrtc: 1.0.15
+  platform_detect: ^2.0.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Bug description (only reproduces in Safari):
After muting the local video track, the remote video track will no longer be displayed.

Not displaying fixed, but causing UI flickering. Still under investigation.