### PR TITLE
Fix resolution/framerate/bitrate issue for publishVideoTrack

### DIFF
--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -155,6 +155,20 @@ class VideoPublishOptions {
     this.screenShareSimulcastLayers = const [],
   });
 
+  VideoPublishOptions copyWith({
+    VideoEncoding? videoEncoding,
+    bool? simulcast,
+    List<VideoParameters>? videoSimulcastLayers,
+    List<VideoParameters>? screenShareSimulcastLayers,
+  }) =>
+      VideoPublishOptions(
+        videoEncoding: videoEncoding ?? this.videoEncoding,
+        simulcast: simulcast ?? this.simulcast,
+        videoSimulcastLayers: videoSimulcastLayers ?? this.videoSimulcastLayers,
+        screenShareSimulcastLayers:
+            screenShareSimulcastLayers ?? this.screenShareSimulcastLayers,
+      );
+
   @override
   String toString() =>
       '${runtimeType}(videoEncoding: ${videoEncoding}, simulcast: ${simulcast})';

--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -323,13 +323,17 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
           .toList();
 
   /// Shortcut for publishing a [TrackSource.camera]
-  Future<LocalTrackPublication?> setCameraEnabled(bool enabled) async {
-    return setSourceEnabled(TrackSource.camera, enabled);
+  Future<LocalTrackPublication?> setCameraEnabled(bool enabled,
+      {CameraCaptureOptions? cameraCaptureOptions}) async {
+    return setSourceEnabled(TrackSource.camera, enabled,
+        cameraCaptureOptions: cameraCaptureOptions);
   }
 
   /// Shortcut for publishing a [TrackSource.microphone]
-  Future<LocalTrackPublication?> setMicrophoneEnabled(bool enabled) async {
-    return setSourceEnabled(TrackSource.microphone, enabled);
+  Future<LocalTrackPublication?> setMicrophoneEnabled(bool enabled,
+      {AudioCaptureOptions? audioCaptureOptions}) async {
+    return setSourceEnabled(TrackSource.microphone, enabled,
+        audioCaptureOptions: audioCaptureOptions);
   }
 
   /// Shortcut for publishing a [TrackSource.screenShareVideo]
@@ -346,6 +350,8 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
   Future<LocalTrackPublication?> setSourceEnabled(
       TrackSource source, bool enabled,
       {bool? captureScreenAudio,
+      AudioCaptureOptions? audioCaptureOptions,
+      CameraCaptureOptions? cameraCaptureOptions,
       ScreenShareCaptureOptions? screenShareCaptureOptions}) async {
     logger.fine('setSourceEnabled(source: $source, enabled: $enabled)');
     final publication = getTrackPublicationBySource(source);
@@ -363,12 +369,14 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
       return publication;
     } else if (enabled) {
       if (source == TrackSource.camera) {
-        final track = await LocalVideoTrack.createCameraTrack(
-            room.roomOptions.defaultCameraCaptureOptions);
+        CameraCaptureOptions captureOptions = cameraCaptureOptions ??
+            room.roomOptions.defaultCameraCaptureOptions;
+        final track = await LocalVideoTrack.createCameraTrack(captureOptions);
         return await publishVideoTrack(track);
       } else if (source == TrackSource.microphone) {
-        final track = await LocalAudioTrack.create(
-            room.roomOptions.defaultAudioCaptureOptions);
+        AudioCaptureOptions captureOptions =
+            audioCaptureOptions ?? room.roomOptions.defaultAudioCaptureOptions;
+        final track = await LocalAudioTrack.create(captureOptions);
         return await publishAudioTrack(track);
       } else if (source == TrackSource.screenShareVideo) {
         ScreenShareCaptureOptions captureOptions = screenShareCaptureOptions ??

--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -113,6 +113,13 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
     publishOptions =
         publishOptions ?? room.roomOptions.defaultVideoPublishOptions;
 
+    // set the default sending bitrate
+    if (publishOptions.videoEncoding == null) {
+      publishOptions = publishOptions.copyWith(
+        videoEncoding: track.currentOptions.params.encoding,
+      );
+    }
+
     // use constraints passed to getUserMedia by default
     VideoDimensions dimensions = track.currentOptions.params.dimensions;
 

--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -175,6 +175,15 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
       init: transceiverInit,
     );
 
+    // prefer to maintainResolution for screen share
+    if (track.source == TrackSource.screenShareVideo) {
+      var sender = track.transceiver!.sender;
+      var parameters = sender.parameters;
+      parameters.degradationPreference =
+          rtc.RTCDegradationPreference.MAINTAIN_RESOLUTION;
+      await sender.setParameters(parameters);
+    }
+
     await room.engine.negotiate();
 
     final pub = LocalTrackPublication<LocalVideoTrack>(

--- a/lib/src/track/options.dart
+++ b/lib/src/track/options.dart
@@ -89,7 +89,7 @@ class ScreenShareCaptureOptions extends VideoCaptureOptions {
     this.captureScreenAudio = false,
     String? sourceId,
     double? maxFrameRate,
-    VideoParameters params = VideoParametersPresets.screenShareH720FPS15,
+    VideoParameters params = VideoParametersPresets.screenShareH1080FPS15,
   }) : super(params: params, deviceId: sourceId, maxFrameRate: maxFrameRate);
 
   ScreenShareCaptureOptions.from(

--- a/lib/src/track/options.dart
+++ b/lib/src/track/options.dart
@@ -28,7 +28,7 @@ class CameraCaptureOptions extends VideoCaptureOptions {
     this.cameraPosition = CameraPosition.front,
     String? deviceId,
     double? maxFrameRate,
-    VideoParameters params = VideoParametersPresets.h540_169,
+    VideoParameters params = VideoParametersPresets.h720_169,
   }) : super(params: params, deviceId: deviceId, maxFrameRate: maxFrameRate);
 
   CameraCaptureOptions.from({required VideoCaptureOptions captureOptions})

--- a/lib/src/track/options.dart
+++ b/lib/src/track/options.dart
@@ -98,6 +98,19 @@ class ScreenShareCaptureOptions extends VideoCaptureOptions {
       required VideoCaptureOptions captureOptions})
       : super(params: captureOptions.params);
 
+  ScreenShareCaptureOptions copyWith({
+    bool? captureScreenAudio,
+    VideoParameters? params,
+    String? sourceId,
+    double? maxFrameRate,
+  }) =>
+      ScreenShareCaptureOptions(
+        captureScreenAudio: captureScreenAudio ?? this.captureScreenAudio,
+        params: params ?? this.params,
+        sourceId: sourceId ?? deviceId,
+        maxFrameRate: maxFrameRate ?? this.maxFrameRate,
+      );
+
   @override
   Map<String, dynamic> toMediaConstraintsMap() {
     var constraints = super.toMediaConstraintsMap();

--- a/lib/src/types/video_parameters.dart
+++ b/lib/src/types/video_parameters.dart
@@ -292,7 +292,7 @@ extension VideoParametersPresets on VideoParameters {
   static const screenShareH1440FPS30 = VideoParameters(
     dimensions: VideoDimensionsPresets.h1440_169,
     encoding: VideoEncoding(
-      maxBitrate: 4 * 1000 * 1000,
+      maxBitrate: 5 * 1000 * 1000,
       maxFramerate: 30,
     ),
   );
@@ -300,7 +300,7 @@ extension VideoParametersPresets on VideoParameters {
   static const screenShareH2160FPS30 = VideoParameters(
     dimensions: VideoDimensionsPresets.h2160_169,
     encoding: VideoEncoding(
-      maxBitrate: 5 * 1000 * 1000,
+      maxBitrate: 8 * 1000 * 1000,
       maxFramerate: 30,
     ),
   );

--- a/lib/src/types/video_parameters.dart
+++ b/lib/src/types/video_parameters.dart
@@ -288,4 +288,20 @@ extension VideoParametersPresets on VideoParameters {
       maxFramerate: 30,
     ),
   );
+
+  static const screenShareH1440FPS30 = VideoParameters(
+    dimensions: VideoDimensionsPresets.h1440_169,
+    encoding: VideoEncoding(
+      maxBitrate: 4 * 1000 * 1000,
+      maxFramerate: 30,
+    ),
+  );
+
+  static const screenShareH2160FPS30 = VideoParameters(
+    dimensions: VideoDimensionsPresets.h2160_169,
+    encoding: VideoEncoding(
+      maxBitrate: 5 * 1000 * 1000,
+      maxFramerate: 30,
+    ),
+  );
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -275,14 +275,12 @@ class Utils {
     required List<VideoParameters> presets,
   }) {
     List<rtc.RTCRtpEncoding> result = [];
-    final rids =
-        videoRids.sublist(videoRids.length - presets.length, videoRids.length);
     presets.forEachIndexed((i, e) {
       if (i >= videoRids.length) {
         return;
       }
       final size = dimensions.min();
-      final rid = rids[i];
+      final rid = videoRids[i];
 
       result.add(e.encoding.toRTCRtpEncoding(
         rid: rid,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -275,12 +275,14 @@ class Utils {
     required List<VideoParameters> presets,
   }) {
     List<rtc.RTCRtpEncoding> result = [];
+    final rids =
+        videoRids.sublist(videoRids.length - presets.length, videoRids.length);
     presets.forEachIndexed((i, e) {
       if (i >= videoRids.length) {
         return;
       }
       final size = dimensions.min();
-      final rid = videoRids[i];
+      final rid = rids[i];
 
       result.add(e.encoding.toRTCRtpEncoding(
         rid: rid,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,10 +23,10 @@ dependencies:
   uuid: ^3.0.6
   synchronized: ^3.0.0+3
   protobuf: ^2.1.0
-  flutter_webrtc: 0.9.25
+  flutter_webrtc: 0.9.26
   flutter_window_close: ^0.2.2
   device_info_plus: ^8.0.0
-  webrtc_interface: 1.0.12
+  webrtc_interface: 1.0.13
   dart_webrtc: 1.0.16
   platform_detect: ^2.0.7
 


### PR DESCRIPTION
* add maintainResolution setting for publish screen sharing track.
* add CaptureOptions for setCameraEnabled/setMicrophoneEnabled/setScreenShareEnabled
* Fix the low bit rate caused by the inability to use the preset encoding parameters when the simulcast is turned off.
* Upgrade flutter-webrtc to 0.9.26, fix the default h264 profile-level-id in iOS/macOS cannot encode 1080p or above resolution.

P.S.
Not sure if it has some issue with simulcast encoding. but after turning off the simulcast, you can get smooth video streaming. will debug again for Android.

https://github.com/livekit/client-sdk-flutter/issues/263
