### PR TITLE
release: 1.3.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## 1.3.1
+
+* Feat: add linux support.
+* Fix: audio play bug for ios safari.
+* Fix: fix bluetooth device enumerate on android.
+* Fix: Do not operate on inactive tracks.
+* Fix: use the correct transceiver id.
+* Fix: Support restart camera for windows/linux.
+* Fix: Move the call of capturer.stopCapture() outside the main thread
+       to avoid blocking of flutter method call.
+* Fix: Handle exceptions for framerate settings for darwin.
+
 ## 1.3.0
 
 * Fix resolution/framerate/bitrate issue for publishVideoTrack.
@@ -13,7 +25,7 @@
 * Feat: handle reconnect response to re-configuration PCs.
 * Docs: readme manager initial setup.
 * Feat: upgrade protocol version to v9.
-* Chore: Use participantIdentity instead of Sid for track permissions. 
+* Chore: Use participantIdentity instead of Sid for track permissions.
 * Feat: Bump flutter-webrtc to 0.9.25.
 * Fix: Fix empty label for Wired Headset on Android.
 * Fix: ICE Connectivity doesn't establish with DualSIM iPhones.
@@ -163,7 +175,7 @@
   video layers that are not being consumed by any subscribers, significantly
   reducing publishing CPU and bandwidth usage. (currently defaults to off)
 * Rename `optimizeVideo` to `adaptiveStream` and improve stability.
-  AdaptiveStream lets LiveKit automatically manage quality of subscribed 
+  AdaptiveStream lets LiveKit automatically manage quality of subscribed
   video tracks to optimize for bandwidth and CPU.
 * Ensure data channel is ready state when `LocalParticipant.publishData` api is called.
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,19 +11,20 @@ dependencies:
   flutter:
     sdk: flutter
 
-  intl: ^0.17.0
+  intl: ^0.18.1
   flutter_background: ^1.1.0
   permission_handler: ^10.2.0
   provider: ^6.0.1
   logging: ^1.0.1
   shared_preferences: ^2.0.7
 
-  google_fonts: ^2.1.0
+  google_fonts: ^4.0.4
   eva_icons_flutter: ^3.0.0
-  flutter_svg: ^1.0.0
+  flutter_svg: ^2.0.5
 
   livekit_client:
     path: ../
+  js_bindings: ^0.1.2+1
     # git:
     #   url: https://github.com/livekit/client-sdk-flutter
     #   ref: main
@@ -31,7 +32,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
 
 # The following section is specific to Flutter.
 flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: livekit_client
 description: Flutter Client SDK for LiveKit.
   Build real-time video and audio into your apps. Supports iOS, Android, and Web.
-version: 1.3.0
+version: 1.3.1
 homepage: https://livekit.io
 
 environment:
@@ -24,7 +24,7 @@ dependencies:
   uuid: ^3.0.6
   synchronized: ^3.0.0+3
   protobuf: ^2.1.0
-  flutter_webrtc: 0.9.28
+  flutter_webrtc: 0.9.30
   flutter_window_close: ^0.2.2
   device_info_plus: ^8.0.0
   webrtc_interface: 1.0.13


### PR DESCRIPTION
## 1.3.1

* Feat: add linux support.
* Fix: audio play bug for ios safari.
* Fix: fix bluetooth device enumerate on android.
* Fix: Do not operate on inactive tracks.
* Fix: use the correct transceiver id.
* Fix: Support restart camera for windows/linux.
* Fix: Move the call of capturer.stopCapture() outside the main thread
       to avoid blocking of flutter method call.
* Fix: Handle exceptions for framerate settings for darwin.

close #279 close #257 close #284