### PR TITLE
Clarifying events in flutter example: reacting to participant events for updating UI

### DIFF
--- a/example/lib/pages/room.dart
+++ b/example/lib/pages/room.dart
@@ -32,7 +32,9 @@ class _RoomPageState extends State<RoomPage> {
   @override
   void initState() {
     super.initState();
+    // add callback for a `RoomEvent` as opposed to a `ParticipantEvent`
     widget.room.addListener(_onRoomDidUpdate);
+    // add callbacks for finer grained events
     _setUpListeners();
     _sortParticipants();
     WidgetsBindingCompatible.instance?.addPostFrameCallback((_) {
@@ -53,6 +55,7 @@ class _RoomPageState extends State<RoomPage> {
     super.dispose();
   }
 
+  /// for more information, see [event types](https://docs.livekit.io/client/events/#events)
   void _setUpListeners() => _listener
     ..on<RoomDisconnectedEvent>((event) async {
       if (event.reason != null) {
@@ -60,6 +63,11 @@ class _RoomPageState extends State<RoomPage> {
       }
       WidgetsBindingCompatible.instance
           ?.addPostFrameCallback((timeStamp) => Navigator.pop(context));
+    })
+    ..on<ParticipantEvent>((event) {
+      print('Participant event');
+      // sort participants on many track events as noted in documentation linked above
+      _sortParticipants();
     })
     ..on<RoomRecordingStatusChanged>((event) {
       context.showRecordingStatusChangedDialog(event.activeRecording);

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -16,6 +16,9 @@ class TrackOption<E extends Object, T extends Object> {
   const TrackOption({this.enabled, this.track});
 }
 
+/// This will enable the local participant to publish tracks on connect,
+/// instead of having to explicitly publish them.
+/// Defaults to false for all three tracks: microphone, camera, and screen.
 class FastConnectOptions {
   FastConnectOptions({
     this.microphone = const TrackOption(enabled: false),

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -19,6 +19,9 @@ class TrackOption<E extends Object, T extends Object> {
 /// This will enable the local participant to publish tracks on connect,
 /// instead of having to explicitly publish them.
 /// Defaults to false for all three tracks: microphone, camera, and screen.
+/// You can also create LocalAudio/VideoTrack on your `PreJoin` page 
+/// (preview camera or select audio device), Automatically publish these
+/// tracks after the room is connected.
 class FastConnectOptions {
   FastConnectOptions({
     this.microphone = const TrackOption(enabled: false),


### PR DESCRIPTION
I ran into issues with implementation and found that some events were not triggered under RoomEvent. Then I found that I needed to listen to the high level `ParticipantEvent` to ensure my UI was accurate when other peers were unpublishing, muting, etc.

This PR hopefully helps with beginners modeling their own code with this example implementation.

- explaining the different listeners and callbacks
- explaining `FastConnectOptions`

Hoping to help more with this process so that the SDK is not a _leaky abstraction._