### PR TITLE
Fix: Use typings instead of js_bindings

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
 
   livekit_client:
     path: ../
-  js_bindings: ^0.1.2+1
+  typings: ^0.0.2
     # git:
     #   url: https://github.com/livekit/client-sdk-flutter
     #   ref: main

--- a/lib/src/track/web/_audio_html.dart
+++ b/lib/src/track/web/_audio_html.dart
@@ -16,7 +16,7 @@ import 'dart:html' as html;
 import 'dart:js_util' as jsutil;
 
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
-import 'package:js_bindings/js_bindings.dart' as js_bindings;
+import 'package:typings/core.dart' as js;
 
 // ignore: implementation_imports
 import 'package:dart_webrtc/src/media_stream_track_impl.dart'; // import_sorter: keep
@@ -24,7 +24,7 @@ import 'package:dart_webrtc/src/media_stream_track_impl.dart'; // import_sorter:
 const audioContainerId = 'livekit_audio_container';
 const audioPrefix = 'livekit_audio_';
 
-js_bindings.AudioContext _audioContext = js_bindings.AudioContext();
+js.AudioContext _audioContext = js.AudioContext();
 Map<String, html.Element> _audioElements = {};
 
 Future<dynamic> startAudio(String id, rtc.MediaStreamTrack track) async {
@@ -57,7 +57,7 @@ Future<bool> startAllAudioElement() async {
       await element.play();
     }
   }
-  return _audioContext.state == js_bindings.AudioContextState.running;
+  return _audioContext.state == js.AudioContextState.running;
 }
 
 void stopAudio(String id) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.13.0"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      sha256: "0c8368c9b3f0abbc193b9d6133649a614204b528982bebc7026372d61677ce3a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.7"
   args:
     dependency: transitive
     description:
@@ -93,10 +101,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   connectivity_plus:
     dependency: "direct main"
     description:
@@ -113,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.4"
+  console:
+    dependency: transitive
+    description:
+      name: console
+      sha256: e04e7824384c5b39389acdd6dc7d33f3efe6b232f6f16d7626f194f6a01ad69a
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   convert:
     dependency: transitive
     description:
@@ -288,14 +304,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
-  js_bindings:
-    dependency: "direct main"
-    description:
-      name: js_bindings
-      sha256: b3374fe1ac1f4a1058f570ab39ae8ada29458c4affaa1ace2772e0abaa5d080f
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.2+2"
   lints:
     dependency: transitive
     description:
@@ -316,18 +324,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: "direct main"
     description:
@@ -448,6 +456,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.5"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.7.3"
   protobuf:
     dependency: "direct main"
     description:
@@ -464,6 +480,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  recase:
+    dependency: transitive
+    description:
+      name: recase
+      sha256: e4eb4ec2dcdee52dcf99cb4ceabaffc631d7424ee55e56f280bc039737f89213
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -481,10 +505,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -529,10 +553,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   tint:
     dependency: transitive
     description:
@@ -541,6 +565,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  ts2dart:
+    dependency: transitive
+    description:
+      name: ts2dart
+      sha256: bfe6e6145235b74547b408b6e454c09814daf267165f98bc2c55743544e6fb92
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.2"
   typed_data:
     dependency: transitive
     description:
@@ -549,6 +581,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  typings:
+    dependency: "direct main"
+    description:
+      name: typings
+      sha256: "426ddada4eca32fe469ed58f8cb9ab5e47216be635cbd451d97c9f5bb4129b01"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.2"
   uuid:
     dependency: "direct main"
     description:
@@ -573,6 +613,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   webrtc_interface:
     dependency: transitive
     description:
@@ -622,5 +670,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   device_info_plus: ^9.0.0
   js: ^0.6.4
   platform_detect: ^2.0.7
-  js_bindings: ^0.1.2+1
+  typings: ^0.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The author of js_bindings has deprecated the library. He has created an alterative called "typings".

This fix switches the uses of "js_bindings" to "typings".

- [ ] **Testing** (I can't find documentation about testing, I have tried to join the Slack but sadly, it doesn't allow me).

Notes: This PR Closes #340 