### PR TITLE
Fix SVC codec bitrate computation

### DIFF
--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -130,10 +130,9 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
     publishOptions =
         publishOptions ?? room.roomOptions.defaultVideoPublishOptions;
 
-    // set the default sending bitrate
-    if (publishOptions.videoEncoding == null) {
+    if (publishOptions.videoCodec.toLowerCase() != publishOptions.videoCodec) {
       publishOptions = publishOptions.copyWith(
-        videoEncoding: track.currentOptions.params.encoding,
+        videoCodec: publishOptions.videoCodec.toLowerCase(),
       );
     }
 
@@ -200,7 +199,7 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
         publishOptions.backupCodec!.codec != publishOptions.videoCodec) {
       simulcastCodecs = <lk_rtc.SimulcastCodec>[
         lk_rtc.SimulcastCodec(
-            codec: publishOptions.videoCodec.toLowerCase(),
+            codec: publishOptions.videoCodec,
             cid: track.getCid(),
             enableSimulcastLayers: true),
         lk_rtc.SimulcastCodec(
@@ -211,7 +210,7 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
     } else {
       simulcastCodecs = <lk_rtc.SimulcastCodec>[
         lk_rtc.SimulcastCodec(
-            codec: publishOptions.videoCodec.toLowerCase(),
+            codec: publishOptions.videoCodec,
             cid: track.getCid(),
             enableSimulcastLayers: publishOptions.simulcast),
       ];
@@ -247,11 +246,10 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
     );
 
     if (lkBrowser() != BrowserType.firefox) {
-      var videoCodec = publishOptions.videoCodec.toLowerCase();
       await room.engine.setPreferredCodec(
         track.transceiver!,
         'video',
-        videoCodec,
+        publishOptions.videoCodec,
       );
       track.codec = videoCodec;
     }

--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -251,7 +251,7 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
         'video',
         publishOptions.videoCodec,
       );
-      track.codec = videoCodec;
+      track.codec = publishOptions.videoCodec;
     }
 
     // prefer to maintainResolution for screen share

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -293,11 +293,11 @@ class Utils {
       switch (codec) {
         case 'av1':
           result =
-              result.copyWith(maxBitrate: (result.maxBitrate * 0.7) as int);
+              result.copyWith(maxBitrate: (result.maxBitrate * 0.7).toInt());
           break;
         case 'vp9':
           result =
-              result.copyWith(maxBitrate: (result.maxBitrate * 0.85) as int);
+              result.copyWith(maxBitrate: (result.maxBitrate * 0.85).toInt());
           break;
         default:
           break;
@@ -442,9 +442,11 @@ class Utils {
       }
       for (int i = 0; i < sm.spatial; i += 1) {
         encodings.add(rtc.RTCRtpEncoding(
-          rid: videoRids[i],
-          maxBitrate: (videoEncoding.maxBitrate / 3 * (i + 1)).toInt(),
+          rid: videoRids[2 - i],
+          maxBitrate: (videoEncoding.maxBitrate / math.pow(3, i)).toInt(),
           maxFramerate: videoEncoding.maxFramerate,
+          scaleResolutionDownBy: null,
+          numTemporalLayers: sm.temporal.toInt(),
         ));
       }
       encodings[0].scalabilityMode = scalabilityMode;
@@ -455,6 +457,7 @@ class Utils {
       return [videoEncoding.toRTCRtpEncoding()];
     }
 
+    // compute simulcast encodings
     final userParams = isScreenShare
         ? options.screenShareSimulcastLayers
         : options.videoSimulcastLayers;

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -443,7 +443,7 @@ class Utils {
       for (int i = 0; i < sm.spatial; i += 1) {
         encodings.add(rtc.RTCRtpEncoding(
           rid: videoRids[2 - i],
-          maxBitrate: (videoEncoding.maxBitrate / math.pow(3, i)).toInt(),
+          maxBitrate: videoEncoding.maxBitrate ~/ math.pow(3, i),
           maxFramerate: videoEncoding.maxFramerate,
           scaleResolutionDownBy: null,
           numTemporalLayers: sm.temporal.toInt(),


### PR DESCRIPTION
Casing double to int would cause a crash. Previously this path wasn't exercised because we've always hardcoded preset bitrate for SVC