### PR TITLE
Fix captureScreenAudio conditional

### DIFF
--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -487,7 +487,7 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
         /// When capturing chrome table audio, we can't capture audio/video
         /// track separately, it has to be returned once in getDisplayMedia,
         /// so we publish it twice here, but only return videoTrack to user.
-        if (captureScreenAudio != null) {
+        if (captureScreenAudio ?? false) {
           captureOptions = captureOptions.copyWith(captureScreenAudio: true);
           final tracks = await LocalVideoTrack.createScreenShareTracksWithAudio(
               captureOptions);


### PR DESCRIPTION
**Expected**
When I pass `false` to `captureScreenAudio`, an audio track should not be created/published to the LiveKit room.

**Actual**
Whenever `captureScreenAudio` is not null, an audio track is always created/published to the LiveKit room regardless of if the variable is `false` or not.

**Fix**
Updated the `captureScreenAudio` conditional to default to `false` if the variable is `null`. Otherwise the actual `true`/`false` value is used for the conditional.