### PR TITLE
Fix iOSBroadcastExtension always false after copyWith invoked

### DIFF
--- a/lib/src/track/options.dart
+++ b/lib/src/track/options.dart
@@ -135,8 +135,8 @@ class ScreenShareCaptureOptions extends VideoCaptureOptions {
     String? selfBrowserSurface,
   }) =>
       ScreenShareCaptureOptions(
-        useiOSBroadcastExtension: useiOSBroadcastExtension ??
-            this.useiOSBroadcastExtension,
+        useiOSBroadcastExtension:
+            useiOSBroadcastExtension ?? this.useiOSBroadcastExtension,
         captureScreenAudio: captureScreenAudio ?? this.captureScreenAudio,
         params: params ?? this.params,
         sourceId: sourceId ?? deviceId,

--- a/lib/src/track/options.dart
+++ b/lib/src/track/options.dart
@@ -126,6 +126,7 @@ class ScreenShareCaptureOptions extends VideoCaptureOptions {
       : super(params: captureOptions.params);
 
   ScreenShareCaptureOptions copyWith({
+    bool? useiOSBroadcastExtension,
     bool? captureScreenAudio,
     VideoParameters? params,
     String? sourceId,
@@ -134,6 +135,8 @@ class ScreenShareCaptureOptions extends VideoCaptureOptions {
     String? selfBrowserSurface,
   }) =>
       ScreenShareCaptureOptions(
+        useiOSBroadcastExtension: useiOSBroadcastExtension ??
+            this.useiOSBroadcastExtension,
         captureScreenAudio: captureScreenAudio ?? this.captureScreenAudio,
         params: params ?? this.params,
         sourceId: sourceId ?? deviceId,


### PR DESCRIPTION
**Expected**
When I pass `true` to `useiOSBroadcastExtension`, the screen-share video track should invoke `getDisplayMedia` with constraints containing `deviceId` set to `broadcast`.

**Actual**
When I pass `true` to `useiOSBroadcastExtension`, the screen-share video instead leaves constraint `deviceId` unset because a prior call to `ScreenShareCaptureOptions#copyWith` always sets `useiOSBroadcastExtension` to the default value of `false`.

```dart
  /// Creates a LocalTracks(audio/video) from the display.
  ///
  /// The current API is mainly used to capture audio when chrome captures tab,
  /// but in the future it can also be used for flutter native to open audio
  /// capture device when capturing screen
  static Future<List<LocalTrack>> createScreenShareTracksWithAudio([
    ScreenShareCaptureOptions? options,
  ]) async {
    if (options == null) {
      options = const ScreenShareCaptureOptions(captureScreenAudio: true);
    } else {
      options = options.copyWith(captureScreenAudio: true); // <-- This line produces the bug
    }

[...]
```

**Fix**
Added support to `ScreenShareCaptureOptions#copyWith` to preserve or overwrite the value of `useiOSBroadcastExtension`.