### PR TITLE
release: 1.5.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## 1.5.3
+
+* Handling of incompatible published codecs.
+* Fix/unpublish screen audio track when stop screen share.
+* Upgrade connectivity_plus version.
+* Fix: low-resolution screen sharing for safari 17.
+* Update build.gradle for gradle 8.0.0 namespace.
+* Fix captureScreenAudio conditional.
+* Fix iOSBroadcastExtension always false after copyWith invoked.
+* Fix: VP9 svc screenshare.
+* Fix iOS example compilation after upgrading to XCode 15.
+* Fix: Crop video output size to target settings (iOS/macOS).
+* Fix: Fix bluetooth sco not stopping after room disconnect (Android).
+
 ## 1.5.2
 
 * Non-functional update, forcing the versions in 

--- a/ios/livekit_client.podspec
+++ b/ios/livekit_client.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = 'livekit_client'
-  s.version             = '1.5.2'
+  s.version             = '1.5.3'
   s.summary             = 'Open source platform for real-time audio and video.'
   s.description         = 'Open source platform for real-time audio and video.'
   s.homepage            = 'https://livekit.io/'

--- a/lib/src/livekit.dart
+++ b/lib/src/livekit.dart
@@ -19,7 +19,7 @@ import 'types/other.dart';
 /// Main entry point to connect to a room.
 /// {@category Room}
 class LiveKitClient {
-  static const version = '1.5.2';
+  static const version = '1.5.3';
 
   /// Convenience method for connecting to a LiveKit server.
   /// Returns a [Room] upon a successful connect or throws when it fails.

--- a/macos/livekit_client.podspec
+++ b/macos/livekit_client.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = 'livekit_client'
-  s.version             = '1.5.2'
+  s.version             = '1.5.3'
   s.summary             = 'Open source platform for real-time audio and video.'
   s.description         = 'Open source platform for real-time audio and video.'
   s.homepage            = 'https://livekit.io/'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@
 name: livekit_client
 description: Flutter Client SDK for LiveKit.
   Build real-time video and audio into your apps. Supports iOS, Android, and Web.
-version: 1.5.2
+version: 1.5.3
 homepage: https://livekit.io
 
 environment:


### PR DESCRIPTION
## 1.5.3

* Handling of incompatible published codecs.
* Fix/unpublish screen audio track when stop screen share.
* Upgrade connectivity_plus version.
* Fix: low-resolution screen sharing for safari 17.
* Update build.gradle for gradle 8.0.0 namespace.
* Fix captureScreenAudio conditional.
* Fix iOSBroadcastExtension always false after copyWith invoked.
* Fix: VP9 svc screenshare.
* Fix iOS example compilation after upgrading to XCode 15.
* Fix: Crop video output size to target settings (iOS/macOS).
* Fix: Fix bluetooth sco not stopping after room disconnect (Android).