### PR TITLE
Fix safari screen sharing failure.

### DIFF
--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -178,10 +178,9 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
       try {
         // try to use getSettings for more accurate resolution
         final settings = track.mediaStreamTrack.getSettings();
-        if (settings['width'] is int && settings['width'] as int > 0) {
+        if ((settings['width'] is int && settings['width'] as int > 0) &&
+            (settings['height'] is int && settings['height'] as int > 0)) {
           dimensions = dimensions.copyWith(width: settings['width'] as int);
-        }
-        if (settings['height'] is int && settings['height'] as int > 0) {
           dimensions = dimensions.copyWith(height: settings['height'] as int);
         }
       } catch (_) {

--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -178,10 +178,10 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
       try {
         // try to use getSettings for more accurate resolution
         final settings = track.mediaStreamTrack.getSettings();
-        if (settings['width'] is int) {
+        if (settings['width'] is int && settings['width'] as int > 0) {
           dimensions = dimensions.copyWith(width: settings['width'] as int);
         }
-        if (settings['height'] is int) {
+        if (settings['height'] is int && settings['height'] as int > 0) {
           dimensions = dimensions.copyWith(height: settings['height'] as int);
         }
       } catch (_) {


### PR DESCRIPTION
Unable to obtain the correct height/width from the safari screen sharing track, which will cause Utils.computeVideoLayers to fail and throw an exception.

close https://github.com/livekit/client-sdk-flutter/issues/413