### PR TITLE
Do not emit Reconnecting event during the connection resume.

### DIFF
--- a/lib/src/core/engine.dart
+++ b/lib/src/core/engine.dart
@@ -746,8 +746,6 @@ class Engine extends Disposable with EventsEmittable<EngineEvent> {
           'resumeConnection: Timed out waiting for SignalReconnectedEvent'),
     );
 
-    events.emit(const EngineSignalResumedEvent());
-
     logger.fine('resumeConnection: reason: ${reason.name}');
 
     if (_hasPublished) {
@@ -774,7 +772,7 @@ class Engine extends Disposable with EventsEmittable<EngineEvent> {
       logger.fine('resumeConnection: primary connected');
     }
 
-    events.emit(const EngineReconnectedEvent());
+    events.emit(const EngineResumedEvent());
   }
 
   @internal

--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -357,14 +357,13 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
     });
 
   void _setUpEngineListeners() => _engineListener
-    ..on<EngineReconnectedEvent>((event) async {
-      events.emit(const RoomReconnectedEvent());
+    ..on<EngineResumedEvent>((event) async {
       // re-send tracks permissions
       localParticipant?.sendTrackSubscriptionPermissions();
       notifyListeners();
     })
     ..on<EngineFullRestartingEvent>((event) async {
-      events.emit(const RoomRestartingEvent());
+      events.emit(const RoomReconnectingEvent());
 
       // clean up RemoteParticipants
       var copy = _remoteParticipants.values.toList();
@@ -385,8 +384,6 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
       notifyListeners();
     })
     ..on<EngineRestartedEvent>((event) async {
-      events.emit(const RoomRestartedEvent());
-
       // re-publish all tracks
       await localParticipant?.rePublishAllTracks();
 
@@ -398,9 +395,9 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
         }
       }
       notifyListeners();
+      events.emit(const RoomReconnectedEvent());
     })
-    ..on<EngineReconnectingEvent>((event) async {
-      events.emit(const RoomReconnectingEvent());
+    ..on<EngineResumingEvent>((event) async {
       await _sendSyncState();
       notifyListeners();
     })

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -90,20 +90,6 @@ class RoomReconnectedEvent with RoomEvent {
   String toString() => '${runtimeType}()';
 }
 
-class RoomRestartingEvent with RoomEvent {
-  const RoomRestartingEvent();
-
-  @override
-  String toString() => '${runtimeType}()';
-}
-
-class RoomRestartedEvent with RoomEvent {
-  const RoomRestartedEvent();
-
-  @override
-  String toString() => '${runtimeType}()';
-}
-
 /// Disconnected from the room
 /// Emitted by [Room].
 class RoomDisconnectedEvent with RoomEvent {

--- a/lib/src/internal/events.dart
+++ b/lib/src/internal/events.dart
@@ -197,18 +197,13 @@ class EngineReconnectingEvent with InternalEvent, EngineEvent {
 }
 
 @internal
-class EngineReconnectedEvent with InternalEvent, EngineEvent {
-  const EngineReconnectedEvent();
+class EngineResumedEvent with InternalEvent, EngineEvent {
+  const EngineResumedEvent();
 }
 
 @internal
 class EngineResumingEvent with InternalEvent, EngineEvent {
   const EngineResumingEvent();
-}
-
-@internal
-class EngineSignalResumedEvent with EngineEvent, InternalEvent {
-  const EngineSignalResumedEvent();
 }
 
 @internal


### PR DESCRIPTION
Removed `RoomRestarting/RoomRestarted` Event and used `RoomReconnecting/RoomReconnected` Event instead