### PR TITLE
fix: use latest key index for new rtp nodes

### DIFF
--- a/lib/src/e2ee/e2ee_manager.dart
+++ b/lib/src/e2ee/e2ee_manager.dart
@@ -16,14 +16,9 @@ import 'package:flutter/foundation.dart';
 
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 
-import '../core/room.dart';
-import '../e2ee/events.dart';
-import '../e2ee/options.dart';
-import '../events.dart';
+import 'package:livekit_client/livekit_client.dart';
 import '../extensions.dart';
-import '../managers/event.dart';
 import '../utils.dart';
-import 'key_provider.dart';
 
 class E2EEManager {
   Room? _room;
@@ -156,7 +151,9 @@ class E2EEManager {
         keyProvider: _keyProvider.keyProvider);
     _frameCryptors[{identity: sid}] = frameCryptor;
     await frameCryptor.setEnabled(_enabled);
-    await frameCryptor.setKeyIndex(0);
+    logger.info(
+        '_addRtpSender, setKeyIndex: ${_keyProvider.getLatestIndex(identity)}');
+    await frameCryptor.setKeyIndex(_keyProvider.getLatestIndex(identity));
     return frameCryptor;
   }
 
@@ -172,7 +169,9 @@ class E2EEManager {
             keyProvider: _keyProvider.keyProvider);
     _frameCryptors[{identity: sid}] = frameCryptor;
     await frameCryptor.setEnabled(_enabled);
-    await frameCryptor.setKeyIndex(0);
+    logger.info(
+        '_addRtpReceiver, setKeyIndex: ${_keyProvider.getLatestIndex(identity)}');
+    await frameCryptor.setKeyIndex(_keyProvider.getLatestIndex(identity));
     return frameCryptor;
   }
 

--- a/lib/src/e2ee/e2ee_manager.dart
+++ b/lib/src/e2ee/e2ee_manager.dart
@@ -16,9 +16,15 @@ import 'package:flutter/foundation.dart';
 
 import 'package:flutter_webrtc/flutter_webrtc.dart';
 
-import 'package:livekit_client/livekit_client.dart';
+import '../core/room.dart';
+import '../events.dart';
 import '../extensions.dart';
+import '../logger.dart';
+import '../managers/event.dart';
 import '../utils.dart';
+import 'events.dart';
+import 'key_provider.dart';
+import 'options.dart';
 
 class E2EEManager {
   Room? _room;

--- a/lib/src/e2ee/key_provider.dart
+++ b/lib/src/e2ee/key_provider.dart
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
+
+import 'package:livekit_client/livekit_client.dart';
 
 const defaultRatchetSalt = 'LKFrameEncryptionKey';
 const defaultMagicBytes = 'LK-ROCKS';
@@ -45,6 +48,11 @@ abstract class KeyProvider {
 
 class BaseKeyProvider implements KeyProvider {
   final Map<String, Map<int, Uint8List>> _keys = {};
+
+  int getLatestIndex(String participantId) {
+    return _keys[participantId]?.keys.last ?? 0;
+  }
+
   Uint8List? _sharedKey;
   final rtc.KeyProviderOptions options;
   final rtc.KeyProvider _keyProvider;
@@ -127,6 +135,8 @@ class BaseKeyProvider implements KeyProvider {
     if (!_keys.containsKey(keyInfo.participantId)) {
       _keys[keyInfo.participantId] = {};
     }
+    logger.info(
+        '_setKey for ${keyInfo.participantId}, idx: ${keyInfo.keyIndex}, key: ${base64Encode(keyInfo.key)}');
     _keys[keyInfo.participantId]![keyInfo.keyIndex] = keyInfo.key;
     await _keyProvider.setKey(
       participantId: keyInfo.participantId,

--- a/lib/src/e2ee/key_provider.dart
+++ b/lib/src/e2ee/key_provider.dart
@@ -17,7 +17,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 
-import 'package:livekit_client/livekit_client.dart';
+import '../logger.dart';
 
 const defaultRatchetSalt = 'LKFrameEncryptionKey';
 const defaultMagicBytes = 'LK-ROCKS';

--- a/web/e2ee.cryptor.dart
+++ b/web/e2ee.cryptor.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: constant_identifier_names
+
 import 'dart:async';
 import 'dart:html';
 import 'dart:js';
@@ -331,6 +333,8 @@ class FrameCryptor {
           'kind': kind,
           'state': 'missingKey',
           'error': 'Missing key for track $trackId',
+          'currentKeyIndex': currentKeyIndex,
+          'secretKey': secretKey.toString()
         });
       }
       return;
@@ -380,7 +384,10 @@ class FrameCryptor {
           'trackId': trackId,
           'kind': kind,
           'state': 'ok',
-          'error': 'encryption ok'
+          'error': 'encryption ok',
+          'frameTrailer': frameTrailer.buffer.asUint8List(),
+          'currentKeyIndex': currentKeyIndex,
+          'secretKey': secretKey.toString(),
         });
       }
 
@@ -471,7 +478,10 @@ class FrameCryptor {
             'trackId': trackId,
             'kind': kind,
             'state': 'missingKey',
-            'error': 'Missing key for track $trackId'
+            'error': 'Missing key for track $trackId',
+            'frameTrailer': frameTrailer.buffer.asUint8List(),
+            'currentKeyIndex': keyIndex,
+            'secretKey': initialKeySet?.encryptionKey.toString()
           });
         }
         controller.enqueue(frame);
@@ -518,7 +528,10 @@ class FrameCryptor {
               'trackId': trackId,
               'kind': kind,
               'state': 'keyRatcheted',
-              'error': 'Key ratcheted ok'
+              'error': 'Key ratcheted ok',
+              'frameTrailer': frameTrailer.buffer.asUint8List(),
+              'currentKeyIndex': currentKeyIndex,
+              'secretKey': currentkeySet.encryptionKey.toString()
             });
           }
         } catch (e) {
@@ -539,9 +552,8 @@ class FrameCryptor {
       }
 
       logger.finer(
-          'buffer: ${buffer.length}, decrypted: ${decrypted?.asUint8List()?.length ?? 0}');
+          'buffer: ${buffer.length}, decrypted: ${decrypted?.asUint8List().length ?? 0}');
       var finalBuffer = BytesBuilder();
-
       finalBuffer.add(Uint8List.fromList(buffer.sublist(0, headerLength)));
       finalBuffer.add(decrypted!.asUint8List());
       frame.data = crypto.jsArrayBufferFrom(finalBuffer.toBytes());
@@ -556,7 +568,10 @@ class FrameCryptor {
           'trackId': trackId,
           'kind': kind,
           'state': 'ok',
-          'error': 'decryption ok'
+          'error': 'decryption ok',
+          'frameTrailer': frameTrailer.buffer.asUint8List(),
+          'currentKeyIndex': currentKeyIndex,
+          'secretKey': currentkeySet.encryptionKey.toString()
         });
       }
 

--- a/web/e2ee.keyhandler.dart
+++ b/web/e2ee.keyhandler.dart
@@ -204,6 +204,7 @@ class ParticipantKeyHandler {
       currentKeyIndex = keyIndex % cryptoKeyRing.length;
     }
     cryptoKeyRing[currentKeyIndex] = keySet;
+    logger.config('setKeySetFromMaterial: currentIndex: $currentKeyIndex');
   }
 
   /// Derives a set of keys from the master key.


### PR DESCRIPTION
fixes a bug where if you already have keys before setting up the rtp{sender, receiver} framecryptors, they frames use key index 0 by default