### PR TITLE
e2ee: Fix createEncodedStreams failure.

### DIFF
--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -90,8 +90,6 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
 
     track.lastPublishOptions = publishOptions;
 
-    await track.start();
-
     final transceiverInit = rtc.RTCRtpTransceiverInit(
       direction: rtc.TransceiverDirection.SendOnly,
       sendEncodings: [
@@ -129,6 +127,8 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
       participant: this,
       publication: pub,
     ));
+
+    await track.start();
 
     return pub;
   }

--- a/lib/src/participant/remote.dart
+++ b/lib/src/participant/remote.dart
@@ -170,8 +170,6 @@ class RemoteParticipant extends Participant<RemoteTrackPublication> {
       throw UnexpectedStateException('Unknown track type');
     }
 
-    await track.start();
-
     /// Apply audio output selection for the web.
     if (pub.kind == TrackType.AUDIO && lkPlatformIs(PlatformType.web)) {
       if (audioOutputOptions.deviceId != null) {
@@ -189,6 +187,8 @@ class RemoteParticipant extends Participant<RemoteTrackPublication> {
       track: track,
       publication: pub,
     ));
+
+    await track.start();
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   device_info_plus: '>=8.0.0'
   js: ^0.6.4
   platform_detect: ^2.0.7
-  dart_webrtc: ^1.4.0
+  dart_webrtc: ^1.4.2
   sdp_transform: ^0.3.2
   web: ^0.5.1
 


### PR DESCRIPTION
After migrating to `package:web`, `AudioElement.srcObject = audioTrack` is called before `createEncodedStreams`, possibly due to `package:web` asynchronous timing changes. Cause E2EE failure.

close https://github.com/livekit/client-sdk-flutter/issues/496