### PR TITLE
fix: use getSettings() to get actual dimensions for mobile

### DIFF
--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -178,8 +178,8 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
     // use constraints passed to getUserMedia by default
     VideoDimensions dimensions = track.currentOptions.params.dimensions;
 
-    if (kIsWeb) {
-      // getSettings() is only implemented for Web
+    if (kIsWeb || lkPlatformIsMobile()) {
+      // getSettings() is only implemented for Web & Mobile
       try {
         // try to use getSettings for more accurate resolution
         final settings = track.mediaStreamTrack.getSettings();


### PR DESCRIPTION
Requires https://github.com/flutter-webrtc/flutter-webrtc/pull/1636 to get actual dimensions.

Addresses https://github.com/webrtc-sdk/webrtc/issues/133