### PR TITLE
Revert "fix: Fixed speaker cannot be switched on iOS."

### DIFF
--- a/lib/src/hardware/hardware.dart
+++ b/lib/src/hardware/hardware.dart
@@ -78,7 +78,7 @@ class Hardware {
 
   bool? speakerOn;
 
-  bool _preferSpeakerOutput = false;
+  bool _preferSpeakerOutput = true;
 
   Future<List<MediaDevice>> enumerateDevices({String? type}) async {
     var infos = await rtc.navigator.mediaDevices.enumerateDevices();


### PR DESCRIPTION
Reverts livekit/client-sdk-flutter#617

and close https://github.com/livekit/client-sdk-flutter/issues/619