### PR TITLE
fix: more robust mirror rendering detection

### DIFF
--- a/lib/src/widgets/video_track_renderer.dart
+++ b/lib/src/widgets/video_track_renderer.dart
@@ -212,6 +212,11 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
     if (widget.mirrorMode == VideoViewMirrorMode.auto) {
       final track = widget.track;
       if (track is LocalVideoTrack) {
+        final settings = track.mediaStreamTrack.getSettings();
+        final facingMode = settings['facingMode'];
+        if (facingMode != null) {
+          return facingMode == 'user';
+        }
         final options = track.currentOptions;
         if (options is CameraCaptureOptions) {
           // mirror if front camera


### PR DESCRIPTION
use track settings (see also https://github.com/flutter-webrtc/flutter-webrtc/pull/1695) to detect front/back facing camera