### PR TITLE
Emit a final empty AudioVisualizerEvent after track stops

### DIFF
--- a/lib/src/track/local/local.dart
+++ b/lib/src/track/local/local.dart
@@ -101,7 +101,7 @@ mixin AudioTrack on Track {
     if (_eventChannel == null) {
       return;
     }
-    
+
     await Native.stopVisualizer(mediaStreamTrack.id!);
     events.emit(AudioVisualizerEvent(
       track: this,

--- a/lib/src/track/local/local.dart
+++ b/lib/src/track/local/local.dart
@@ -101,7 +101,12 @@ mixin AudioTrack on Track {
     if (_eventChannel == null) {
       return;
     }
+    
     await Native.stopVisualizer(mediaStreamTrack.id!);
+    events.emit(AudioVisualizerEvent(
+      track: this,
+      event: [],
+    ));
     await _streamSubscription?.cancel();
     _streamSubscription = null;
     _eventChannel = null;


### PR DESCRIPTION
This makes it easy for consumers to zero themselves out on mute, etc. An empty array should be safe, consumers will automatically fill in the zero values based on their expected size. 