### PR TITLE
fix: remove unnecessary debug print statement from logs (Video-Stats)

### DIFF
--- a/lib/src/track/local/video.dart
+++ b/lib/src/track/local/video.dart
@@ -117,9 +117,6 @@ class LocalVideoTrack extends LocalTrack with VideoTrack {
     }
 
     final stats = await sender!.getStats();
-    print(
-        'sender stats: ${stats.map((e) => 'id: ${e.id}, type:  ${e.type}, timestamp: ${e.timestamp}, values: ${e.values.toString()} ')}');
-    print('sender stats: ${stats.map((e) => e.values.toString())}');
     List<VideoSenderStats> items = [];
     for (var v in stats) {
       if (v.type == 'outbound-rtp') {


### PR DESCRIPTION
This fix removes an unnecessary `print("sender stats:")` statement from the logs in the `video.dart` class.