### PR TITLE
Fix: fix mute republish & track stop.

### DIFF
--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -451,10 +451,13 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
     }
   }
 
-  Future<void> rePublishAllTracks() async {
+  Future<void> rePublishAllTracks({
+    bool republishMutedTrack = false,
+  }) async {
     final tracks = trackPublications.values.toList();
     trackPublications.clear();
     for (LocalTrackPublication track in tracks) {
+      if (!republishMutedTrack && track.track != null && track.track!.muted) continue;
       if (track.track is LocalAudioTrack) {
         await publishAudioTrack(track.track as LocalAudioTrack);
       } else if (track.track is LocalVideoTrack) {

--- a/lib/src/track/remote/remote.dart
+++ b/lib/src/track/remote/remote.dart
@@ -46,7 +46,7 @@ abstract class RemoteTrack extends Track {
   @override
   Future<bool> stop() async {
     final didStop = await super.stop();
-    if (didStop || !muted) {
+    if (didStop/* || !muted*/) {
       await disable();
     }
     return didStop;


### PR DESCRIPTION
1、When room restart, add the parameter control if can republish mute track, default is false.
2、Remote track stop do not check mute flag.