### PR TITLE
fix: improve browser version detection

### DIFF
--- a/lib/src/support/platform/web.dart
+++ b/lib/src/support/platform/web.dart
@@ -67,8 +67,8 @@ BrowserType lkBrowserImplementation() {
 }
 
 BrowserVersion lkBrowserVersionImplementation() {
-  var ua = web.window.navigator.userAgent;
-  var appVersion = web.window.navigator.appVersion;
+  final ua = web.window.navigator.userAgent;
+  final appVersion = web.window.navigator.appVersion;
 
   BrowserVersion chromeBased(String prefix) {
     Match? match =
@@ -92,8 +92,8 @@ BrowserVersion lkBrowserVersionImplementation() {
         return BrowserVersion(0, 0, 0);
       }
 
-      var major = int.parse(match.group(1)!);
-      var minor = int.parse(match.group(2)!);
+      final major = int.parse(match.group(1)!);
+      final minor = int.parse(match.group(2)!);
       return BrowserVersion(major, minor, 0);
     case BrowserType.safari:
       Match? match =
@@ -109,22 +109,22 @@ BrowserVersion lkBrowserVersionImplementation() {
     case BrowserType.internetExplorer:
       Match? match = RegExp(r'MSIE (\d+)\.(\d+);').firstMatch(appVersion);
       if (match != null) {
-        var major = int.parse(match.group(1)!);
-        var minor = int.parse(match.group(2)!);
+        final major = int.parse(match.group(1)!);
+        final minor = int.parse(match.group(2)!);
         return BrowserVersion(major, minor, 0);
       }
 
       match = RegExp(r'rv[: ](\d+)\.(\d+)').firstMatch(appVersion);
       if (match != null) {
-        var major = int.parse(match.group(1)!);
-        var minor = int.parse(match.group(2)!);
+        final major = int.parse(match.group(1)!);
+        final minor = int.parse(match.group(2)!);
         return BrowserVersion(major, minor, 0);
       }
 
       match = RegExp(r'Edge/(\d+)\.(\d+)$').firstMatch(appVersion);
       if (match != null) {
-        var major = int.parse(match.group(1)!);
-        var minor = int.parse(match.group(2)!);
+        final major = int.parse(match.group(1)!);
+        final minor = int.parse(match.group(2)!);
         return BrowserVersion(major, minor, 0);
       }
 

--- a/lib/src/support/platform/web.dart
+++ b/lib/src/support/platform/web.dart
@@ -67,12 +67,82 @@ BrowserType lkBrowserImplementation() {
 }
 
 BrowserVersion lkBrowserVersionImplementation() {
+  var ua = web.window.navigator.userAgent;
   var appVersion = web.window.navigator.appVersion;
-  Match match =
-      RegExp(r'Version/(\d+)(\.(\d+))?(\.(\d+))?').firstMatch(appVersion)!;
-  var major = int.parse(match.group(1)!);
-  var minor = int.parse(match.group(3) ?? '0');
-  var patch = int.parse(match.group(5) ?? '0');
 
-  return BrowserVersion(major, minor, patch);
+  BrowserVersion chromeBased(String prefix) {
+    Match? match =
+        RegExp(prefix + r'/(\d+)\.(\d+)\.(\d+)\.(\d+)').firstMatch(appVersion);
+    if (match == null) {
+      return BrowserVersion(0, 0, 0);
+    }
+
+    final major = int.parse(match.group(1)!);
+    final minor = int.parse(match.group(2)!);
+    final patch = int.parse(match.group(3)!);
+    return BrowserVersion(major, minor, patch);
+  }
+
+  switch (lkBrowserImplementation()) {
+    case BrowserType.chrome:
+      return chromeBased('Chrome');
+    case BrowserType.firefox:
+      Match? match = RegExp(r'rv:(\d+)\.(\d+)\)').firstMatch(ua);
+      if (match == null) {
+        return BrowserVersion(0, 0, 0);
+      }
+
+      var major = int.parse(match.group(1)!);
+      var minor = int.parse(match.group(2)!);
+      return BrowserVersion(major, minor, 0);
+    case BrowserType.safari:
+      Match? match =
+          RegExp(r'Version/(\d+)(\.(\d+))?(\.(\d+))?').firstMatch(appVersion);
+      if (match == null) {
+        return BrowserVersion(0, 0, 0);
+      }
+
+      final major = int.parse(match.group(1)!);
+      final minor = int.parse(match.group(3) ?? '0');
+      final patch = int.parse(match.group(5) ?? '0');
+      return BrowserVersion(major, minor, patch);
+    case BrowserType.internetExplorer:
+      Match? match = RegExp(r'MSIE (\d+)\.(\d+);').firstMatch(appVersion);
+      if (match != null) {
+        var major = int.parse(match.group(1)!);
+        var minor = int.parse(match.group(2)!);
+        return BrowserVersion(major, minor, 0);
+      }
+
+      match = RegExp(r'rv[: ](\d+)\.(\d+)').firstMatch(appVersion);
+      if (match != null) {
+        var major = int.parse(match.group(1)!);
+        var minor = int.parse(match.group(2)!);
+        return BrowserVersion(major, minor, 0);
+      }
+
+      match = RegExp(r'Edge/(\d+)\.(\d+)$').firstMatch(appVersion);
+      if (match != null) {
+        var major = int.parse(match.group(1)!);
+        var minor = int.parse(match.group(2)!);
+        return BrowserVersion(major, minor, 0);
+      }
+
+      return BrowserVersion(0, 0, 0);
+    case BrowserType.wkWebView:
+      Match? match =
+          RegExp(r'AppleWebKit/(\d+)\.(\d+)\.(\d+)').firstMatch(appVersion);
+      if (match == null) {
+        return BrowserVersion(0, 0, 0);
+      }
+
+      final major = int.parse(match.group(1)!);
+      final minor = int.parse(match.group(2)!);
+      final patch = int.parse(match.group(3)!);
+      return BrowserVersion(major, minor, patch);
+    case BrowserType.edge:
+      return chromeBased('Edg');
+    default:
+      return BrowserVersion(0, 0, 0);
+  }
 }


### PR DESCRIPTION
This PR improves the detection of browser versions across Chrome, Firefox, Safari, Internet Explorer, Web Kit, and Edge. In scenarios where the browser version cannot be parsed, a version number of 0.0.0 is returned.

Fixes https://github.com/livekit/client-sdk-flutter/issues/736