### PR TITLE
fix: Fix creation timing for local participant.

### DIFF
--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -668,6 +668,14 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
     // trigger change notifier only if list of participants membership is changed
     var hasChanged = false;
     for (final info in updates) {
+      // The local participant is not ready yet, waiting for the
+      // `RoomConnectedEvent` to create the local participant.
+      if (_localParticipant == null) {
+        await events.waitFor<RoomConnectedEvent>(
+          duration: const Duration(seconds: 10),
+        );
+      }
+
       if (localParticipant?.identity == info.identity) {
         await localParticipant?.updateFromInfo(info);
         continue;

--- a/lib/src/participant/participant.dart
+++ b/lib/src/participant/participant.dart
@@ -200,6 +200,7 @@ abstract class Participant<T extends TrackPublication>
 
   @internal
   Future<bool> updateFromInfo(lk_models.ParticipantInfo info) async {
+    logger.fine('LocalParticipant.updateFromInfo(info: $info)');
     if (_participantInfo != null &&
         _participantInfo!.sid == info.sid &&
         _participantInfo!.version > info.version) {


### PR DESCRIPTION
In fast track publish mode, join and update messages will arrive at the client almost at the same time, so we need to wait for the join process to complete and create the LocalParticipant before processing the update message.