### PR TITLE
Fix: calling setSourceEnabled should not affect the current output settings

### DIFF
--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -732,7 +732,6 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
           await publication.mute(stopOnMute: stopOnMute);
         }
       }
-      await room.applyAudioSpeakerSettings();
       return publication;
     } else if (enabled) {
       if (source == TrackSource.camera) {


### PR DESCRIPTION
Issue: Muting the microphone causes the audio output to switch from the headset to the system speakers, despite the output initially being routed through the headset. This behavior is misleading and unintended.

Whenver `setSourceEnabled` is called to mute a track source, `await room.applyAudioSpeakerSettings();` is triggered as well.

Additional information:
`setSourceEnabled` is called by `setCameraEnabled`, `setMicrophoneEnabled`, `setScreenShareEnabled`.

Next, `setCameraEnabled`, `setMicrophoneEnabled`, `setScreenShareEnabled` are called via `_setUpEngineListeners`, based on `FastConnectOptions`. 

There should not be any impact on the current implementation.