### PR TITLE
Expose Agent Track Amplitude Levels

### DIFF
--- a/lib/src/core/engine.dart
+++ b/lib/src/core/engine.dart
@@ -1164,30 +1164,17 @@ class Engine extends Disposable with EventsEmittable<EngineEvent> {
 
   Future<void> _logAudioLevel() async {
     if (subscriber == null || subscriber?.pc == null) {
-      // Check subscriber first
       return;
     }
     if (_monitoredAudioTrackId == null) {
-      // Log if the ID is null when the function runs
-      print(
-          '[${objectId}] _logAudioLevel: Skipping, _monitoredAudioTrackId is still null.');
       return;
     }
 
-    // Log the monitored ID each time just before fetching stats
-    print(
-        '[${objectId}] _logAudioLevel: Current _monitoredAudioTrackId: $_monitoredAudioTrackId');
-
     try {
       final stats = await subscriber!.pc.getStats();
-      print('[${objectId}] gonna log audio level'); // Confirm entry
       for (final report in stats) {
-        // Focus on inbound-rtp reports
         if (report.type == 'inbound-rtp') {
           final trackIdFromReport = report.values['trackIdentifier'];
-          // Print the values being compared for debugging
-          print(
-              '[${objectId}] Comparing IDs: Report="${trackIdFromReport}" vs Monitored="${_monitoredAudioTrackId}"');
 
           if (trackIdFromReport == _monitoredAudioTrackId &&
               report.values['mediaType'] == 'audio') {
@@ -1199,19 +1186,12 @@ class Engine extends Disposable with EventsEmittable<EngineEvent> {
 
               // Call the callback instead of emitting event
               onAudioLevelUpdate?.call(_monitoredAudioTrackId!, audioLevel);
-
-              // Keep print/log for debugging if needed
-              logger.info(
-                  'Remote audio level for track $_monitoredAudioTrackId: $audioLevel');
-              print(
-                  '!!! SUCCESS: Remote audio level for track $_monitoredAudioTrackId: $audioLevel');
             }
-            break; // Found the relevant report, no need to continue
+            break;
           }
         }
       }
     } catch (e) {
-      // Use logger for errors
       logger.warning('Error getting stats: $e');
     }
   }

--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -157,13 +157,14 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
             Engine(
               roomOptions: roomOptions,
             ) {
-    // Assign callback in the body if engine was created here
-    if (engine == null) {
-      this.engine.onAudioLevelUpdate =
-          (trackId, level) => _handleEngineAudioLevelUpdate(trackId, level);
-    }
+    // Note that if engine was externally provided and the creator used onAudioLevelUpdate,
+    // this will lead to a silent override. Feels OK because this is really intended just
+    // for the Room class to use.
+    // Multi-listener for the engine felt overkill because the room already has multiple
+    // listeners.
+    this.engine.onAudioLevelUpdate =
+        (trackId, level) => _handleEngineAudioLevelUpdate(trackId, level);
 
-    //
     _engineListener = this.engine.createListener();
     _setUpEngineListeners();
 
@@ -941,9 +942,9 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
   // Handler for audio level updates from the engine
   void _handleEngineAudioLevelUpdate(String trackId, double level) {
     bool needsNotify = true;
-    // Only notify if the level actually changed significantly
+    // Alt: Only notify if the level actually changed significantly
     // to avoid excessive UI updates.
-    // You might adjust the threshold (e.g., 0.02) or remove it
+    // We might adjust the threshold (e.g., 0.02) or remove it
     // if you need every single update.
     // if ((remoteTrackAudioLevels[trackId] ?? -1.0 - level).abs() < 0.02) {
     //   needsNotify = false;


### PR DESCRIPTION
This allows users of the flutter SDK to subscribe to the agent amplitude levels.

```
void _handleAudioLevelChange() {

    final audioLevels = room!.remoteTrackAudioLevels;
    final maxLevel = audioLevels.values.isNotEmpty
        ? audioLevels.values.reduce((a, b) => a > b ? a : b)
        : 0.0;
    // maxLevel now gives us the normalized amplitude of the agent track
}

// Note that the Room object itself is a ChangeNotifier. We implemented the logic
// so that the Engine calls a callback (_handleEngineAudioLevelUpdate) on the
// Room instance every 50ms. Inside that handler, the Room updates its
// remoteTrackAudioLevels map and, crucially, calls notifyListeners() on itself.
room.addListener(_handleAudioLevelChange);
```

I really want to get actual PCM data, but that seems more complicated