### PR TITLE
Fix smoothTransition option issues

### DIFF
--- a/android/src/main/kotlin/io/livekit/plugin/Visualizer.kt
+++ b/android/src/main/kotlin/io/livekit/plugin/Visualizer.kt
@@ -84,6 +84,8 @@ class Visualizer(
             bands = bands.mapIndexed { index, value ->
                 smoothTransition(value, amplitudes[index], 0.3f)
             }.toFloatArray()
+        } else {
+            bands = amplitudes
         }
 
         handler.post {

--- a/lib/src/track/audio_visualizer_web.dart
+++ b/lib/src/track/audio_visualizer_web.dart
@@ -34,7 +34,19 @@ class AudioVisualizerWeb extends AudioVisualizer {
 
     final bands = visualizerOptions.barCount;
 
-    _audioAnalyser = createAudioAnalyser(_audioTrack!, options.analyserOptions);
+    // Override smoothingTimeConstant to a very low valiue if smoothTransition is false
+    var currentAnalyserOptions =
+        options.analyserOptions ?? const AudioAnalyserOptions();
+    if (!visualizerOptions.smoothTransition) {
+      currentAnalyserOptions = AudioAnalyserOptions(
+        fftSize: currentAnalyserOptions.fftSize,
+        maxDecibels: currentAnalyserOptions.maxDecibels,
+        minDecibels: currentAnalyserOptions.minDecibels,
+        smoothingTimeConstant: 0.02,
+      );
+    }
+
+    _audioAnalyser = createAudioAnalyser(_audioTrack!, currentAnalyserOptions);
 
     final bufferLength = _audioAnalyser?.analyser.frequencyBinCount;
 
@@ -52,9 +64,7 @@ class AudioVisualizerWeb extends AudioVisualizer {
           frequencies = frequencies.sublist(
               options.loPass!.toInt(), options.hiPass!.toInt());
 
-          final normalizedFrequencies = visualizerOptions.smoothTransition
-              ? normalizeFrequencies(frequencies)
-              : frequencies;
+          final normalizedFrequencies = normalizeFrequencies(frequencies);
           final chunkSize = (normalizedFrequencies.length / (bands + 1)).ceil();
           Float32List chunks = Float32List(visualizerOptions.barCount);
 


### PR DESCRIPTION
- Web: uses `smoothingTimeConstant` within `AudioAnalyserOptions` instead
- Android: fixes missing assignment