### PR TITLE
fix: Always emit RoomDisconnectedEvent when the reason is clientInitiated.

### DIFF
--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -552,7 +552,8 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
       notifyListeners();
     })
     ..on<EngineDisconnectedEvent>((event) async {
-      if (!engine.fullReconnectOnNext) {
+      if (!engine.fullReconnectOnNext ||
+          event.reason == DisconnectReason.clientInitiated) {
         await _cleanUp(disposeLocalParticipant: false);
         events.emit(RoomDisconnectedEvent(reason: event.reason));
         notifyListeners();


### PR DESCRIPTION
close https://github.com/livekit/client-sdk-flutter/issues/799