### PR TITLE
Fix linux build error

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -11,6 +11,8 @@ project(${PROJECT_NAME} LANGUAGES CXX C)
 # not be changed.
 set(PLUGIN_NAME "livekit_client_plugin")
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_definitions(-D_USE_MATH_DEFINES)
 add_definitions(-DRTC_DESKTOP_DEVICE)


### PR DESCRIPTION
I ran into a build issue on Linux when using this package. It relies on C++17 features, but without explicitly setting the C++ standard in the package's CMakeLists.txt, the build system was defaulting to an older version.