### PR TITLE
Fix publications' track property initialization

### DIFF
--- a/lib/src/publication/local.dart
+++ b/lib/src/publication/local.dart
@@ -31,8 +31,7 @@ class LocalTrackPublication<T extends LocalTrack> extends TrackPublication<T> {
     required this.participant,
     required lk_models.TrackInfo info,
     required T track,
-  }) : super(info: info) {
-    updateTrack(track);
+  }) : super(info: info, track: track) {
     // register dispose func
     onDispose(() async {
       // this object is responsible for disposing track

--- a/lib/src/publication/remote.dart
+++ b/lib/src/publication/remote.dart
@@ -105,7 +105,7 @@ class RemoteTrackPublication<T extends RemoteTrack>
     required this.participant,
     required lk_models.TrackInfo info,
     T? track,
-  }) : super(info: info) {
+  }) : super(info: info, track: track) {
     logger.fine('RemoteTrackPublication.init track: $track, info: $info');
 
     // register dispose func
@@ -121,8 +121,6 @@ class RemoteTrackPublication<T extends RemoteTrack>
       cancelFunc: (func) => _cancelPendingTrackSettingsUpdateRequest = func,
       wait: const Duration(milliseconds: 1500),
     );
-
-    updateTrack(track);
   }
 
   @internal


### PR DESCRIPTION
The constructors of `LocalTrackPublication` and `RemoteTrackPublication` relied on setting the `track` property during initialization. However, because `updateTrack()` was an un-awaited async method, the `track` property was null immediately after construction, which caused confusion.