### PR TITLE
Minor session messages optimization

### DIFF
--- a/lib/src/agent/session.dart
+++ b/lib/src/agent/session.dart
@@ -270,7 +270,7 @@ class Session extends DisposableChangeNotifier {
               (message) => MapEntry(message.id, message),
             ),
       );
-    _refreshMessagesView();
+    _updateMessagesView();
     notifyListeners();
   }
 
@@ -290,7 +290,7 @@ class Session extends DisposableChangeNotifier {
           final shouldNotify = existing != message;
           _messages[message.id] = message;
           if (shouldNotify) {
-            _refreshMessagesView();
+            _updateMessagesView();
             notifyListeners();
           }
         },
@@ -303,7 +303,7 @@ class Session extends DisposableChangeNotifier {
     }
   }
 
-  void _refreshMessagesView() {
+  void _updateMessagesView() {
     _messagesView = UnmodifiableListView(_messages.values.toList(growable: false));
   }
 


### PR DESCRIPTION
Cache Session.messages as an UnmodifiableListView and refresh it only when the underlying map changes, instead of recreating a new unmodifiable list on every getter call. This keeps the data immutable but gives widgets a stable reference, reducing unnecessary rebuilds.