### PR TITLE
fix: Enable E2EE for VP9 codec

### DIFF
--- a/lib/src/e2ee/e2ee_manager.dart
+++ b/lib/src/e2ee/e2ee_manager.dart
@@ -21,6 +21,7 @@ import '../events.dart';
 import '../extensions.dart';
 import '../logger.dart';
 import '../managers/event.dart';
+import '../utils.dart';
 import 'events.dart';
 import 'key_provider.dart';
 import 'options.dart';
@@ -45,7 +46,8 @@ class E2EEManager {
       _listener = _room!.createListener();
       _listener!
         ..on<LocalTrackPublishedEvent>((event) async {
-          if (event.publication.encryptionType == EncryptionType.kNone) {
+          if (event.publication.encryptionType == EncryptionType.kNone ||
+              isAV1Codec(event.publication.track?.codec ?? '')) {
             // no need to setup frame cryptor
             return;
           }
@@ -79,7 +81,7 @@ class E2EEManager {
         })
         ..on<TrackSubscribedEvent>((event) async {
           final codec = event.publication.mimeType.split('/')[1];
-          if (event.publication.encryptionType == EncryptionType.kNone) {
+          if (event.publication.encryptionType == EncryptionType.kNone || isAV1Codec(codec)) {
             // no need to setup frame cryptor
             return;
           }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -567,6 +567,8 @@ const refreshSubscribedCodecAfterNewCodec = 5000;
 
 bool isSVCCodec(String codec) => ['vp9', 'av1'].contains(codec.toLowerCase());
 
+bool isAV1Codec(String codec) => codec.toLowerCase() == 'av1';
+
 class ScalabilityMode {
   late num spatial;
 


### PR DESCRIPTION
### Problem
While using the Flutter SDK with JS SDK and with E2EE enabled, the video from Web can not be decrypted by the Flutter app.

## Summary
Enables end-to-end encryption (E2EE) for VP9 codec. Previously, E2EE was skipped for all SVC codecs. This aligns the Flutter SDK with the JS SDK, where E2EE works with VP9 codec.

## Changes
Removed `isSVCCodec()` and use `isAV1Codec()` to enable E2EE setup for VP9 codec in `LocalTrackPublishedEvent` handler
Removed `isSVCCodec()` and use `isAV1Codec()` to enable E2EE setup for VP9 codec in `TrackSubscribedEvent` handler

Is there any specific reason why E2EE is disabled for SVC codecs? 
I tried VP9 with this patch and the VP9 video from Web can be decrypted by Flutter app.