### PR TITLE
fix: set proper mute state for audio/video tracks after reconnection

### DIFF
--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -134,6 +134,7 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
       name: publishOptions.name ?? AudioPublishOptions.defaultMicrophoneName,
       type: track.kind.toPBType(),
       source: track.source.toPBType(),
+      muted: track.muted,
       stream: buildStreamId(publishOptions, track.source),
       disableDtx: !publishOptions.dtx,
       disableRed: room.e2eeManager != null ? true : publishOptions.red ?? true,
@@ -361,7 +362,7 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
       source: track.source.toPBType(),
       encryption: room.roomOptions.lkEncryptionType,
       simulcastCodecs: simulcastCodecs,
-      muted: false,
+      muted: track.muted,
       stream: buildStreamId(publishOptions, track.source),
     );
 


### PR DESCRIPTION
Closes https://github.com/livekit/client-sdk-flutter/issues/962

### How does it fix that?

The methods `publishAudioTrack` and `publishVideoTrack` are called on call reconnection here -
https://github.com/livekit/client-sdk-flutter/blob/70d4d1f5fdc6f565cbe565e3d5a50d5c23b5ddef/lib/src/participant/local.dart#L560-L570

But inside the methods we're not passing the `muted` state from the old tracks we have. It defaults to `false` because it's not set in protobuf:
https://github.com/livekit/client-sdk-flutter/blob/70d4d1f5fdc6f565cbe565e3d5a50d5c23b5ddef/lib/src/proto/livekit_rtc.pb.dart#L1153

By passing it correctly, this PR fixes the bug in the linked issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the muted state of audio and video tracks was not being correctly propagated when publishing to the server.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->