### PR TITLE
Ensure mute state stays in sync after reconnect

### DIFF
--- a/.changes/reconcile-local-mute-state
+++ b/.changes/reconcile-local-mute-state
@@ -1,1 +1,1 @@
-patch type="fixed" "Reconcile local track mute state with server updates"
+patch type="fixed" "Keep mute state in sync with server"

--- a/.changes/reconnect-track-mute-state
+++ b/.changes/reconnect-track-mute-state
@@ -1,1 +1,0 @@
-patch type="fixed" "Set correct mute state in add-track requests after reconnect"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mute state synchronization to ensure the client's local mute status remains in sync with the server, preventing inconsistencies during track publishing and codec operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->