### PR TITLE
fix: debounce for ensurePublisherConnected.

### DIFF
--- a/lib/src/core/engine.dart
+++ b/lib/src/core/engine.dart
@@ -506,7 +506,12 @@ class Engine extends Disposable with EventsEmittable<EngineEvent> {
   @internal
   Future<void> ensurePublisherConnected() async {
     _publisherConnectionFuture ??= _publisherEnsureConnected();
-    await _publisherConnectionFuture;
+    try {
+      await _publisherConnectionFuture;
+    } catch (_) {
+      _publisherConnectionFuture = null;
+      rethrow;
+    }
   }
 
   lk_models.EncryptedPacketPayload? asEncryptablePacket(lk_models.DataPacket packet) {
@@ -1123,6 +1128,8 @@ class Engine extends Disposable with EventsEmittable<EngineEvent> {
 
       await publisher?.dispose();
       publisher = null;
+
+      _publisherConnectionFuture = null;
 
       await subscriber?.dispose();
       subscriber = null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved publisher connection stability by centralizing connection handling, adding a single awaited connection flow with automatic reset on failure, and ensuring connections are cleared and retried after restarts or when peer connection states become closed/failed/disconnected. This reduces race conditions and improves reliability for publishing and data sending paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->