### PR TITLE
fix: prevent adding events to closed StreamController

### DIFF
--- a/lib/src/types/data_stream.dart
+++ b/lib/src/types/data_stream.dart
@@ -161,9 +161,17 @@ class DataStreamController<T extends DataStream_Chunk> {
 
   Future<void> close() => streamController.close();
 
-  void write(T chunk) => streamController.add(chunk);
+  void write(T chunk) {
+    if (!streamController.isClosed) {
+      streamController.add(chunk);
+    }
+  }
 
-  void error(DataStreamError error) => streamController.addError(error);
+  void error(DataStreamError error) {
+    if (!streamController.isClosed) {
+      streamController.addError(error);
+    }
+  }
 }
 
 class ByteStreamInfo extends BaseStreamInfo {


### PR DESCRIPTION
Add isClosed checks to DataStreamController's write() and error() methods to prevent "Bad state: Cannot add event after closing" exception.

This error occurs when a participant disconnects and validateParticipantHasNoActiveDataStreams() tries to send errors to stream controllers that have already been closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by preventing errors when operations are attempted on closed data streams. The system now gracefully handles edge cases where write or error operations occur after stream closure, ensuring more reliable behavior without throwing exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->