### PR TITLE
Fix start local audio

### DIFF
--- a/.changes/fix-audio-visualizer-unpublished-track
+++ b/.changes/fix-audio-visualizer-unpublished-track
@@ -1,0 +1,1 @@
+patch type="fixed" "Fix audio visualizer not working for unpublished local audio tracks"

--- a/lib/src/hardware/hardware.dart
+++ b/lib/src/hardware/hardware.dart
@@ -14,8 +14,9 @@
 
 import 'dart:async';
 
-import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
+
+import 'package:collection/collection.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 
 import '../logger.dart';

--- a/lib/src/hardware/hardware.dart
+++ b/lib/src/hardware/hardware.dart
@@ -15,6 +15,7 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 
 import '../logger.dart';
@@ -192,6 +193,31 @@ class Hardware {
       'audio': false,
       'video': device != null ? constraints : true,
     });
+  }
+
+  /// Explicitly starts the audio device module's recording pipeline.
+  ///
+  /// This is called automatically when a [LocalAudioTrack] is started, but
+  /// can be called manually for pre-join scenarios (e.g. audio visualization
+  /// before connecting to a room).
+  ///
+  /// No-ops on web. Safe to call multiple times (idempotent).
+  Future<void> startLocalRecording() async {
+    if (!kIsWeb) {
+      await rtc.NativeAudioManagement.startLocalRecording();
+    }
+  }
+
+  /// Stops the audio device module's recording pipeline.
+  ///
+  /// Normally you don't need to call this — WebRTC manages the ADM lifecycle.
+  /// Use this only for explicit control (e.g. CallKit flows).
+  ///
+  /// No-ops on web.
+  Future<void> stopLocalRecording() async {
+    if (!kIsWeb) {
+      await rtc.NativeAudioManagement.stopLocalRecording();
+    }
   }
 
   dynamic _onDeviceChange(dynamic _) async {

--- a/lib/src/track/local/audio.dart
+++ b/lib/src/track/local/audio.dart
@@ -114,7 +114,7 @@ class LocalAudioTrack extends LocalTrack with AudioTrack, LocalAudioManagementMi
 
   @override
   Future<bool> start() async {
-    if (isStarted) return false;
+    if (isActive) return false;
     if (!kIsWeb) {
       await rtc.NativeAudioManagement.startLocalRecording();
     }

--- a/lib/src/track/local/audio.dart
+++ b/lib/src/track/local/audio.dart
@@ -14,8 +14,9 @@
 
 import 'dart:async';
 
-import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
+
+import 'package:collection/collection.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 import 'package:meta/meta.dart';
 

--- a/lib/src/track/local/audio.dart
+++ b/lib/src/track/local/audio.dart
@@ -114,6 +114,7 @@ class LocalAudioTrack extends LocalTrack with AudioTrack, LocalAudioManagementMi
 
   @override
   Future<bool> start() async {
+    if (isStarted) return false;
     if (!kIsWeb) {
       await rtc.NativeAudioManagement.startLocalRecording();
     }

--- a/lib/src/track/local/audio.dart
+++ b/lib/src/track/local/audio.dart
@@ -15,6 +15,7 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 import 'package:meta/meta.dart';
 
@@ -108,6 +109,14 @@ class LocalAudioTrack extends LocalTrack with AudioTrack, LocalAudioManagementMi
       }
     }
     return senderStats;
+  }
+
+  @override
+  Future<bool> start() async {
+    if (!kIsWeb) {
+      await rtc.NativeAudioManagement.startLocalRecording();
+    }
+    return await super.start();
   }
 
   // private constructor

--- a/lib/src/track/track.dart
+++ b/lib/src/track/track.dart
@@ -52,11 +52,15 @@ abstract class Track extends DisposableChangeNotifier with EventsEmittable<Track
   String? _cid;
 
   // started / stopped
-  bool _active = false;
-  bool get isActive => _active;
+  bool _isStarted = false;
+  bool get isStarted => _isStarted;
+  @Deprecated('Use isStarted instead')
+  bool get isActive => _isStarted;
 
-  bool _muted = false;
-  bool get muted => _muted;
+  bool _isMuted = false;
+  bool get isMuted => _isMuted;
+  @Deprecated('Use isMuted instead')
+  bool get muted => _isMuted;
 
   rtc.RTCRtpSender? get sender => transceiver?.sender;
 
@@ -103,7 +107,7 @@ abstract class Track extends DisposableChangeNotifier with EventsEmittable<Track
   /// Returns true if started, false if already started
   @mustCallSuper
   Future<bool> start() async {
-    if (_active) {
+    if (_isStarted) {
       // already started
       return false;
     }
@@ -114,7 +118,7 @@ abstract class Track extends DisposableChangeNotifier with EventsEmittable<Track
 
     await onStarted();
 
-    _active = true;
+    _isStarted = true;
     return true;
   }
 
@@ -122,7 +126,7 @@ abstract class Track extends DisposableChangeNotifier with EventsEmittable<Track
   /// Returns true if stopped, false if already stopped
   @mustCallSuper
   Future<bool> stop() async {
-    if (!_active) {
+    if (!_isStarted) {
       // already stopped
       return false;
     }
@@ -142,14 +146,14 @@ abstract class Track extends DisposableChangeNotifier with EventsEmittable<Track
       _originalTrack = null;
     }
 
-    _active = false;
+    _isStarted = false;
     return true;
   }
 
   Future<void> enable() async {
     logger.fine('$objectId.enable() enabling ${mediaStreamTrack.objectId}...');
     try {
-      if (_active) {
+      if (_isStarted) {
         mediaStreamTrack.enabled = true;
       }
     } catch (e) {
@@ -160,7 +164,7 @@ abstract class Track extends DisposableChangeNotifier with EventsEmittable<Track
   Future<void> disable() async {
     logger.fine('$objectId.disable() disabling ${mediaStreamTrack.objectId}...');
     try {
-      if (_active) {
+      if (_isStarted) {
         mediaStreamTrack.enabled = false;
       }
     } catch (e) {
@@ -200,8 +204,8 @@ abstract class Track extends DisposableChangeNotifier with EventsEmittable<Track
     bool shouldNotify = true,
     bool shouldSendSignal = false,
   }) {
-    if (_muted == muted) return;
-    _muted = muted;
+    if (_isMuted == muted) return;
+    _isMuted = muted;
     if (shouldNotify) {
       events.emit(InternalTrackMuteUpdatedEvent(
         track: this,

--- a/lib/src/track/track.dart
+++ b/lib/src/track/track.dart
@@ -52,15 +52,11 @@ abstract class Track extends DisposableChangeNotifier with EventsEmittable<Track
   String? _cid;
 
   // started / stopped
-  bool _isStarted = false;
-  bool get isStarted => _isStarted;
-  @Deprecated('Use isStarted instead')
-  bool get isActive => _isStarted;
+  bool _active = false;
+  bool get isActive => _active;
 
-  bool _isMuted = false;
-  bool get isMuted => _isMuted;
-  @Deprecated('Use isMuted instead')
-  bool get muted => _isMuted;
+  bool _muted = false;
+  bool get muted => _muted;
 
   rtc.RTCRtpSender? get sender => transceiver?.sender;
 
@@ -107,7 +103,7 @@ abstract class Track extends DisposableChangeNotifier with EventsEmittable<Track
   /// Returns true if started, false if already started
   @mustCallSuper
   Future<bool> start() async {
-    if (_isStarted) {
+    if (_active) {
       // already started
       return false;
     }
@@ -118,7 +114,7 @@ abstract class Track extends DisposableChangeNotifier with EventsEmittable<Track
 
     await onStarted();
 
-    _isStarted = true;
+    _active = true;
     return true;
   }
 
@@ -126,7 +122,7 @@ abstract class Track extends DisposableChangeNotifier with EventsEmittable<Track
   /// Returns true if stopped, false if already stopped
   @mustCallSuper
   Future<bool> stop() async {
-    if (!_isStarted) {
+    if (!_active) {
       // already stopped
       return false;
     }
@@ -146,14 +142,14 @@ abstract class Track extends DisposableChangeNotifier with EventsEmittable<Track
       _originalTrack = null;
     }
 
-    _isStarted = false;
+    _active = false;
     return true;
   }
 
   Future<void> enable() async {
     logger.fine('$objectId.enable() enabling ${mediaStreamTrack.objectId}...');
     try {
-      if (_isStarted) {
+      if (_active) {
         mediaStreamTrack.enabled = true;
       }
     } catch (e) {
@@ -164,7 +160,7 @@ abstract class Track extends DisposableChangeNotifier with EventsEmittable<Track
   Future<void> disable() async {
     logger.fine('$objectId.disable() disabling ${mediaStreamTrack.objectId}...');
     try {
-      if (_isStarted) {
+      if (_active) {
         mediaStreamTrack.enabled = false;
       }
     } catch (e) {
@@ -204,8 +200,8 @@ abstract class Track extends DisposableChangeNotifier with EventsEmittable<Track
     bool shouldNotify = true,
     bool shouldSendSignal = false,
   }) {
-    if (_isMuted == muted) return;
-    _isMuted = muted;
+    if (_muted == muted) return;
+    _muted = muted;
     if (shouldNotify) {
       events.emit(InternalTrackMuteUpdatedEvent(
         track: this,


### PR DESCRIPTION
Ensure native ADM is started when track.start() is called so audio frames get generated (for visualizer)
Also expose manual adm start/stop methods.