### PR TITLE
chore: Fix example app build failures on CI

### DIFF
--- a/.changes/bump-agp-version
+++ b/.changes/bump-agp-version
@@ -1,0 +1,1 @@
+patch type="fixed" "Bump Android Gradle plugin to 8.9.1"

--- a/.changes/bump-agp-version
+++ b/.changes/bump-agp-version
@@ -1,1 +1,1 @@
-patch type="fixed" "Bump Android Gradle plugin to 8.9.1"
+patch type="fixed" "Fix example app build failures on CI"

--- a/.changes/bump-agp-version
+++ b/.changes/bump-agp-version
@@ -1,1 +1,0 @@
-patch type="fixed" "Fix example app build failures on CI"

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Nov 14 15:55:14 CST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.7.2' apply false
+    id "com.android.application" version '8.9.1' apply false
     id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -26,9 +26,9 @@ dependencies:
     path: ../
 
 dependency_overrides:
-  # connectivity_plus 7.1.0 uses NWPath.isUltraConstrained which requires
-  # a newer Xcode SDK than current CI runners have.
-  connectivity_plus: '>=7.0.0 <7.1.0'
+  # Pin packages that use Apple APIs unavailable on CI runner's Xcode version.
+  connectivity_plus: '>=7.0.0 <7.1.0' # NWPath.isUltraConstrained
+  device_info_plus: '>=12.3.0 <12.4.0' # NSProcessInfo.isiOSAppOnVision
 
 dev_dependencies:
   flutter_test:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -25,6 +25,11 @@ dependencies:
   livekit_client:
     path: ../
 
+dependency_overrides:
+  # connectivity_plus 7.1.0 uses NWPath.isUltraConstrained which requires
+  # a newer Xcode SDK than current CI runners have.
+  connectivity_plus: '>=7.0.0 <7.1.0'
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Fixes example app build failure caused by androidx.core:core-ktx 1.18.0 requiring AGP 8.9.1+.