### PR TITLE
Specify correct video size on adaptive stream

### DIFF
--- a/lib/src/publication/remote.dart
+++ b/lib/src/publication/remote.dart
@@ -16,6 +16,7 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/widgets.dart';
+
 import 'package:meta/meta.dart';
 
 import '../core/signal_client.dart';

--- a/lib/src/publication/remote.dart
+++ b/lib/src/publication/remote.dart
@@ -16,7 +16,6 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/widgets.dart';
-
 import 'package:meta/meta.dart';
 
 import '../core/signal_client.dart';
@@ -149,25 +148,24 @@ class RemoteTrackPublication<T extends RemoteTrack> extends TrackPublication<T> 
       disabled: true,
     );
 
-    // filter visible build contexts
-    final viewSizes = videoTrack.viewKeys
-        .map((e) => e.currentContext)
-        .nonNulls
-        .map((e) => e.findRenderObject() as RenderBox?)
-        .nonNulls
-        .where((e) => e.hasSize)
-        .map((e) => e.size);
+    final videoViewsSizes = <Size>[];
+    for (var key in videoTrack.viewKeys) {
+      final context = key.currentContext;
+      if (context == null) continue;
+      final renderBox = context.findRenderObject() as RenderBox?;
+      if (renderBox == null || !renderBox.hasSize) continue;
+      videoViewsSizes.add(renderBox.size * MediaQuery.of(context).devicePixelRatio);
+    }
 
-    logger.finer('[Visibility] ${track?.sid} watching ${viewSizes.length} views...');
+    logger.finer('[Visibility] ${track?.sid} watching ${videoViewsSizes.length} views...');
 
-    if (viewSizes.isNotEmpty) {
-      // compute largest size
-      final largestSize = viewSizes.reduce((value, element) => maxOfSizes(value, element));
+    if (videoViewsSizes.isNotEmpty) {
+      final largestVideoView = videoViewsSizes.reduce((value, element) => maxOfSizes(value, element));
 
       settings
         ..disabled = false
-        ..width = largestSize.width.ceil()
-        ..height = largestSize.height.ceil();
+        ..width = largestVideoView.width.ceil()
+        ..height = largestVideoView.height.ceil();
     }
 
     // Only send new settings to server if it changed

--- a/lib/src/publication/remote.dart
+++ b/lib/src/publication/remote.dart
@@ -143,7 +143,7 @@ class RemoteTrackPublication<T extends RemoteTrack> extends TrackPublication<T> 
     if (videoTrack == null) return;
     if (videoTrack.viewSizes[viewViewId] == size) return;
 
-    logger.finer('[Visibility] VideoView did resize');
+    print('[Visibility] VideoView did resize to ${size.width}x${size.height}, quick: ${quick}');
     videoTrack.viewSizes[viewViewId] = size;
 
     final settings = lk_rtc.UpdateTrackSettings(
@@ -205,6 +205,7 @@ class RemoteTrackPublication<T extends RemoteTrack> extends TrackPublication<T> 
           }
         };
         newValue.onViewViewResize = (viewId, size) {
+          // schedule update to server
           updateVideoViewSize(viewId, size);
         };
       }

--- a/lib/src/publication/remote.dart
+++ b/lib/src/publication/remote.dart
@@ -141,15 +141,18 @@ class RemoteTrackPublication<T extends RemoteTrack> extends TrackPublication<T> 
     assert(track is VideoTrack, 'updateVideoViewSize can only be called on video tracks');
     final videoTrack = track as VideoTrack?;
     if (videoTrack == null) return;
+    if (videoTrack.viewSizes[viewViewId] == null) {
+      logger.warning(
+        'Trying to update video view size ${size} for a view ${viewViewId} that is not registered or was unregistered',
+      );
+      return;
+    }
     if (videoTrack.viewSizes[viewViewId] == size) return;
 
     print('[Visibility] VideoView did resize to ${size.width}x${size.height}, quick: ${quick}');
     videoTrack.viewSizes[viewViewId] = size;
 
-    final settings = lk_rtc.UpdateTrackSettings(
-      trackSids: [sid],
-      disabled: true,
-    );
+    final settings = lk_rtc.UpdateTrackSettings(trackSids: [sid], disabled: true);
 
     final videoViewsSizes = <Size>[
       for (final MapEntry(key: _, value: size) in videoTrack.viewSizes.entries)
@@ -163,8 +166,8 @@ class RemoteTrackPublication<T extends RemoteTrack> extends TrackPublication<T> 
 
       settings
         ..disabled = false
-        ..width = largestVideoView.width.ceil()
-        ..height = largestVideoView.height.ceil();
+        ..width = largestVideoView.width.round()
+        ..height = largestVideoView.height.round();
     }
 
     // Only send new settings to server if it changed

--- a/lib/src/publication/remote.dart
+++ b/lib/src/publication/remote.dart
@@ -96,7 +96,6 @@ class RemoteTrackPublication<T extends RemoteTrack> extends TrackPublication<T> 
   // used to report renderer visibility to the server
   // and optimize
   lk_rtc.UpdateTrackSettings? _lastSentTrackSettings;
-  Timer? _visibilityTimer;
 
   Function(lk_rtc.UpdateTrackSettings)? _setPendingTrackSettingsUpdateRequest;
   Function? _cancelPendingTrackSettingsUpdateRequest;
@@ -111,7 +110,6 @@ class RemoteTrackPublication<T extends RemoteTrack> extends TrackPublication<T> 
     // register dispose func
     onDispose(() async {
       _cancelPendingTrackSettingsUpdateRequest?.call();
-      _visibilityTimer?.cancel();
       // this object is responsible for disposing track
       await this.track?.dispose();
     });
@@ -132,35 +130,36 @@ class RemoteTrackPublication<T extends RemoteTrack> extends TrackPublication<T> 
     _metadataMuted = info.muted;
   }
 
-  void _computeVideoViewVisibility({
-    bool quick = false,
-  }) {
-    //
-    Size maxOfSizes(Size s1, Size s2) => Size(
-          max(s1.width, s2.width),
-          max(s1.height, s2.height),
-        );
+  Size _maxOfSizes(Size s1, Size s2) => Size(
+        max(s1.width, s2.width),
+        max(s1.height, s2.height),
+      );
 
-    final videoTrack = track as VideoTrack;
+  /// Requests the server to send a new track with the given settings.
+  @internal
+  void updateVideoViewSize(String viewViewId, Size size, {bool quick = false}) {
+    assert(track is VideoTrack, 'updateVideoViewSize can only be called on video tracks');
+    final videoTrack = track as VideoTrack?;
+    if (videoTrack == null) return;
+    if (videoTrack.viewSizes[viewViewId] == size) return;
+
+    logger.finer('[Visibility] VideoView did resize');
+    videoTrack.viewSizes[viewViewId] = size;
 
     final settings = lk_rtc.UpdateTrackSettings(
       trackSids: [sid],
       disabled: true,
     );
 
-    final videoViewsSizes = <Size>[];
-    for (var key in videoTrack.viewKeys) {
-      final context = key.currentContext;
-      if (context == null) continue;
-      final renderBox = context.findRenderObject() as RenderBox?;
-      if (renderBox == null || !renderBox.hasSize) continue;
-      videoViewsSizes.add(renderBox.size * MediaQuery.of(context).devicePixelRatio);
-    }
+    final videoViewsSizes = <Size>[
+      for (final MapEntry(key: _, value: size) in videoTrack.viewSizes.entries)
+        if (size > Size.zero) size,
+    ];
 
     logger.finer('[Visibility] ${track?.sid} watching ${videoViewsSizes.length} views...');
 
     if (videoViewsSizes.isNotEmpty) {
-      final largestVideoView = videoViewsSizes.reduce((value, element) => maxOfSizes(value, element));
+      final largestVideoView = videoViewsSizes.reduce((value, element) => _maxOfSizes(value, element));
 
       settings
         ..disabled = false
@@ -194,23 +193,19 @@ class RemoteTrackPublication<T extends RemoteTrack> extends TrackPublication<T> 
     if (didUpdate) {
       // Stop current visibility timer (if exists)
       _cancelPendingTrackSettingsUpdateRequest?.call();
-      _visibilityTimer?.cancel();
 
       final roomOptions = participant.room.roomOptions;
       if (roomOptions.adaptiveStream && newValue is RemoteVideoTrack) {
-        // Start monitoring visibility
-        _visibilityTimer = Timer.periodic(
-          const Duration(milliseconds: 300),
-          (_) => _computeVideoViewVisibility(),
-        );
-
-        newValue.onVideoViewBuild = (_) {
+        newValue.onVideoViewBuild = (viewId, size) {
           logger.finer('[Visibility] VideoView did build');
           if (_lastSentTrackSettings?.disabled == true) {
             // quick enable
             _cancelPendingTrackSettingsUpdateRequest?.call();
-            _computeVideoViewVisibility(quick: true);
+            updateVideoViewSize(viewId, size, quick: true);
           }
+        };
+        newValue.onViewViewResize = (viewId, size) {
+          updateVideoViewSize(viewId, size);
         };
       }
 

--- a/lib/src/track/local/local.dart
+++ b/lib/src/track/local/local.dart
@@ -16,6 +16,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 import 'package:meta/meta.dart';
 

--- a/lib/src/track/local/local.dart
+++ b/lib/src/track/local/local.dart
@@ -49,7 +49,7 @@ mixin VideoTrack on Track {
   Function(String, Size)? onViewViewResize;
 
   @internal
-  String registerVideoView(Size size) {
+  String registerVideoView([Size size = Size.zero]) {
     final id = Track.uuid.v4();
     viewSizes[id] = size;
     return id;

--- a/lib/src/track/local/local.dart
+++ b/lib/src/track/local/local.dart
@@ -16,7 +16,6 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
-
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 import 'package:meta/meta.dart';
 
@@ -41,21 +40,24 @@ import 'video.dart';
 /// Used to group [LocalVideoTrack] and [RemoteVideoTrack].
 mixin VideoTrack on Track {
   @internal
-  final List<GlobalKey> viewKeys = [];
+  final Map<String, Size> viewSizes = {};
 
   @internal
-  Function(Key)? onVideoViewBuild;
+  Function(String, Size)? onVideoViewBuild;
 
   @internal
-  GlobalKey addViewKey() {
-    final key = GlobalKey();
-    viewKeys.add(key);
-    return key;
+  Function(String, Size)? onViewViewResize;
+
+  @internal
+  String registerVideoView(Size size) {
+    final id = Track.uuid.v4();
+    viewSizes[id] = size;
+    return id;
   }
 
   @internal
-  void removeViewKey(GlobalKey key) {
-    viewKeys.remove(key);
+  void unregisterVideoView(String id) {
+    viewSizes.remove(id);
   }
 }
 

--- a/lib/src/widgets/video_track_renderer.dart
+++ b/lib/src/widgets/video_track_renderer.dart
@@ -17,7 +17,6 @@ import 'dart:math';
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
-
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 
 import '../events.dart';
@@ -136,6 +135,8 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
     }
   }
 
+  Timer? _resizeDebounceTimer;
+
   @override
   void initState() {
     super.initState();
@@ -145,6 +146,13 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
     _internalId = widget.track.registerVideoView();
     WidgetsBindingCompatible.instance?.addPostFrameCallback((timeStamp) {
       widget.track.onVideoViewBuild?.call(_internalId, _computedSize);
+    });
+
+    _resizeDebounceTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (!mounted) return;
+      final size = _computedSize;
+      if (size.isEmpty) return;
+      widget.track.onViewViewResize?.call(_internalId, size);
     });
 
     if (kIsWeb) {
@@ -158,6 +166,7 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
 
   @override
   void dispose() {
+    _resizeDebounceTimer?.cancel();
     widget.track.unregisterVideoView(_internalId);
     unawaited(_listener?.dispose());
     if (widget.autoDisposeRenderer) {

--- a/lib/src/widgets/video_track_renderer.dart
+++ b/lib/src/widgets/video_track_renderer.dart
@@ -17,6 +17,7 @@ import 'dart:math';
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 
 import '../events.dart';
@@ -135,8 +136,6 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
     }
   }
 
-  Timer? _resizeDebounceTimer;
-
   @override
   void initState() {
     super.initState();
@@ -146,13 +145,6 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
     _internalId = widget.track.registerVideoView();
     WidgetsBindingCompatible.instance?.addPostFrameCallback((timeStamp) {
       widget.track.onVideoViewBuild?.call(_internalId, _computedSize);
-    });
-
-    _resizeDebounceTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
-      if (!mounted) return;
-      final size = _computedSize;
-      if (size.isEmpty) return;
-      widget.track.onViewViewResize?.call(_internalId, size);
     });
 
     if (kIsWeb) {
@@ -166,7 +158,6 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
 
   @override
   void dispose() {
-    _resizeDebounceTimer?.cancel();
     widget.track.unregisterVideoView(_internalId);
     unawaited(_listener?.dispose());
     if (widget.autoDisposeRenderer) {

--- a/lib/src/widgets/video_track_renderer.dart
+++ b/lib/src/widgets/video_track_renderer.dart
@@ -332,7 +332,7 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
       },
     );
 
-    if (widget.autoCenter) {
+    if (widget.autoCenter && widget.fit == VideoViewFit.contain) {
       return Center(child: videoView);
     } else {
       return videoView;

--- a/lib/src/widgets/video_track_renderer.dart
+++ b/lib/src/widgets/video_track_renderer.dart
@@ -17,7 +17,6 @@ import 'dart:math';
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
-
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 
 import '../events.dart';
@@ -90,8 +89,8 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
   bool _rendererReadyForWeb = false;
   double? _aspectRatio;
   EventsListener<TrackEvent>? _listener;
-  // Used to compute visibility information
-  late GlobalKey _internalKey;
+  late String _internalId;
+  Key get _internalKey => ValueKey('${widget.track.sid}_$_internalId');
 
   Future<rtc.VideoRenderer> _initializeRenderer() async {
     if (lkPlatformIs(PlatformType.iOS) && widget.renderMode == VideoRenderMode.platformView) {
@@ -142,7 +141,7 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
     if (widget.cachedRenderer != null) {
       _renderer = widget.cachedRenderer;
     }
-    _internalKey = widget.track.addViewKey();
+    _internalId = widget.track.registerVideoView(Size.zero);
     if (kIsWeb) {
       unawaited(() async {
         await _initializeRenderer();
@@ -154,7 +153,7 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
 
   @override
   void dispose() {
-    widget.track.removeViewKey(_internalKey);
+    widget.track.unregisterVideoView(_internalId);
     unawaited(_listener?.dispose());
     if (widget.autoDisposeRenderer) {
       disposeRenderer();
@@ -188,8 +187,9 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
   void didUpdateWidget(covariant VideoTrackRenderer oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.track != oldWidget.track) {
-      oldWidget.track.removeViewKey(_internalKey);
-      _internalKey = widget.track.addViewKey();
+      oldWidget.track.unregisterVideoView(_internalId);
+      _internalId = widget.track.registerVideoView(Size.zero);
+
       unawaited(() async {
         await _attach();
       }());
@@ -200,14 +200,15 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
     }
   }
 
-  Widget _videoViewForWeb() => !_rendererReadyForWeb
+  Widget _videoViewForWeb(Size size) => !_rendererReadyForWeb
       ? Container()
       : Builder(
           key: _internalKey,
           builder: (ctx) {
             // let it render before notifying build
             WidgetsBindingCompatible.instance?.addPostFrameCallback((timeStamp) {
-              widget.track.onVideoViewBuild?.call(_internalKey);
+              widget.track.onVideoViewBuild?.call(_internalId, size);
+              widget.track.onViewViewResize?.call(_internalId, size);
             });
             return rtc.RTCVideoView(
               _renderer! as rtc.RTCVideoRenderer,
@@ -238,7 +239,7 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
     );
   }
 
-  Widget _videoViewForNative() => FutureBuilder(
+  Widget _videoViewForNative(Size size) => FutureBuilder(
       future: _initializeRenderer(),
       builder: (context, snapshot) {
         if ((snapshot.hasData && _renderer != null) ||
@@ -248,7 +249,8 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
             builder: (ctx) {
               // let it render before notifying build
               WidgetsBindingCompatible.instance?.addPostFrameCallback((timeStamp) {
-                widget.track.onVideoViewBuild?.call(_internalKey);
+                widget.track.onVideoViewBuild?.call(_internalId, size);
+                widget.track.onViewViewResize?.call(_internalId, size);
               });
 
               if (!lkPlatformIsMobile() || widget.track is! LocalVideoTrack) {
@@ -278,14 +280,19 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
   // different rendering methods for web and native.
   @override
   Widget build(BuildContext context) {
-    final child = kIsWeb ? _videoViewForWeb() : _videoViewForNative();
-
-    if (widget.fit == VideoViewFit.cover) {
-      return child;
-    }
-
     final videoView = LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
+        final size = constraints.biggest * MediaQuery.of(context).devicePixelRatio;
+
+        final child = kIsWeb ? _videoViewForWeb(size) : _videoViewForNative(size);
+
+        if (widget.fit == VideoViewFit.cover) {
+          return child;
+        }
+
+        if (size.isEmpty) {
+          return child;
+        }
         if (!constraints.hasBoundedWidth && !constraints.hasBoundedHeight) {
           return child;
         }

--- a/lib/src/widgets/video_track_renderer.dart
+++ b/lib/src/widgets/video_track_renderer.dart
@@ -17,6 +17,7 @@ import 'dart:math';
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 
 import '../events.dart';

--- a/lib/src/widgets/video_track_renderer.dart
+++ b/lib/src/widgets/video_track_renderer.dart
@@ -141,7 +141,11 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
     if (widget.cachedRenderer != null) {
       _renderer = widget.cachedRenderer;
     }
-    _internalId = widget.track.registerVideoView(Size.zero);
+    _internalId = widget.track.registerVideoView();
+    WidgetsBindingCompatible.instance?.addPostFrameCallback((timeStamp) {
+      widget.track.onVideoViewBuild?.call(_internalId, _computedSize);
+    });
+
     if (kIsWeb) {
       unawaited(() async {
         await _initializeRenderer();
@@ -159,6 +163,13 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
       disposeRenderer();
     }
     super.dispose();
+  }
+
+  Size get _computedSize {
+    if (!mounted) return Size.zero;
+    final box = context.findRenderObject() as RenderBox?;
+    if (box == null) return Size.zero;
+    return box.size * MediaQuery.of(context).devicePixelRatio;
   }
 
   Future<void> _attach() async {
@@ -188,7 +199,7 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
     super.didUpdateWidget(oldWidget);
     if (widget.track != oldWidget.track) {
       oldWidget.track.unregisterVideoView(_internalId);
-      _internalId = widget.track.registerVideoView(Size.zero);
+      _internalId = widget.track.registerVideoView();
 
       unawaited(() async {
         await _attach();
@@ -207,7 +218,6 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
           builder: (ctx) {
             // let it render before notifying build
             WidgetsBindingCompatible.instance?.addPostFrameCallback((timeStamp) {
-              widget.track.onVideoViewBuild?.call(_internalId, size);
               widget.track.onViewViewResize?.call(_internalId, size);
             });
             return rtc.RTCVideoView(
@@ -249,7 +259,6 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
             builder: (ctx) {
               // let it render before notifying build
               WidgetsBindingCompatible.instance?.addPostFrameCallback((timeStamp) {
-                widget.track.onVideoViewBuild?.call(_internalId, size);
                 widget.track.onViewViewResize?.call(_internalId, size);
               });
 


### PR DESCRIPTION
This update replaces the previous polling-based system with a more efficient, event-driven approach for calculating video view dimensions.

Removed the 300ms timer that previously polled for layout changes. The system now calls updateVideoViewSize only when an actual width change is detected.

Video dimensions are now calculated by multiplying the view size by the device pixel ratio, ensuring the feed matches the hardware's native resolution.

Eliminated cached GlobalKeys and expensive RenderBox calculations to reduce overhead.