### PR TITLE
Align screen-share simulcast default lower layer

### DIFF
--- a/.changes/align-screenshare-simulcast-defaults
+++ b/.changes/align-screenshare-simulcast-defaults
@@ -1,0 +1,1 @@
+patch type="fixed" "Align screen share simulcast defaults"

--- a/.changes/align-screenshare-simulcast-defaults
+++ b/.changes/align-screenshare-simulcast-defaults
@@ -1,1 +1,1 @@
-patch type="fixed" "Align screen share simulcast defaults"
+patch type="fixed" "Align screen share simulcast default low layer"

--- a/lib/src/types/video_parameters.dart
+++ b/lib/src/types/video_parameters.dart
@@ -274,7 +274,7 @@ extension VideoParametersPresets on VideoParameters {
   static const screenShareH720FPS5 = VideoParameters(
     dimensions: VideoDimensionsPresets.h720_169,
     encoding: VideoEncoding(
-      maxBitrate: 400 * 1000,
+      maxBitrate: 800 * 1000,
       maxFramerate: 5,
     ),
   );
@@ -298,7 +298,7 @@ extension VideoParametersPresets on VideoParameters {
   static const screenShareH1080FPS30 = VideoParameters(
     dimensions: VideoDimensionsPresets.h1080_169,
     encoding: VideoEncoding(
-      maxBitrate: 4000 * 1000,
+      maxBitrate: 5000 * 1000,
       maxFramerate: 30,
     ),
   );

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -229,23 +229,24 @@ class Utils {
   static List<VideoParameters> _computeDefaultScreenShareSimulcastParams({
     required VideoParameters original,
   }) {
-    final layers = [rtc.RTCRtpEncoding(scaleResolutionDownBy: 2, maxFramerate: 3)];
-    return layers.map((e) {
-      final scale = e.scaleResolutionDownBy ?? 1;
-      final fps = e.maxFramerate ?? 3;
+    final originalEncoding = original.encoding!;
+    const scale = 2.0;
 
-      return VideoParameters(
+    return [
+      VideoParameters(
         dimensions:
             VideoDimensions((original.dimensions.width / scale).floor(), (original.dimensions.height / scale).floor()),
         encoding: VideoEncoding(
           maxBitrate: math.max(
             150 * 1000,
-            (original.encoding!.maxBitrate / (math.pow(scale, 2) * (original.encoding!.maxFramerate / fps))).floor(),
+            (originalEncoding.maxBitrate / math.pow(scale, 2)).floor(),
           ),
-          maxFramerate: fps,
+          maxFramerate: originalEncoding.maxFramerate,
+          bitratePriority: originalEncoding.bitratePriority,
+          networkPriority: originalEncoding.networkPriority,
         ),
-      );
-    }).toList();
+      ),
+    ];
   }
 
   static List<VideoParameters> _computeDefaultSimulcastParams({

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -58,6 +58,11 @@ void main() {
   });
 
   group('screen share simulcast encodings', () {
+    test('screen share preset bitrates match common SDK presets', () {
+      expect(lk.VideoParametersPresets.screenShareH720FPS5.encoding?.maxBitrate, 800000);
+      expect(lk.VideoParametersPresets.screenShareH1080FPS30.encoding?.maxBitrate, 5000000);
+    });
+
     test('default lower layer follows top layer fps and priorities', () {
       final encodings = Utils.computeVideoEncodings(
         isScreenShare: true,

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 
+import 'package:livekit_client/livekit_client.dart' as lk;
 import 'package:livekit_client/src/utils.dart';
 
 void main() {
@@ -53,5 +55,32 @@ void main() {
         completion('result-1'),
       ),
     );
+  });
+
+  group('screen share simulcast encodings', () {
+    test('default lower layer follows top layer fps and priorities', () {
+      final encodings = Utils.computeVideoEncodings(
+        isScreenShare: true,
+        dimensions: const lk.VideoDimensions(1920, 1080),
+        options: const lk.VideoPublishOptions(
+          screenShareEncoding: lk.VideoEncoding(
+            maxBitrate: 2500000,
+            maxFramerate: 15,
+            bitratePriority: lk.Priority.high,
+            networkPriority: lk.Priority.high,
+          ),
+        ),
+      );
+
+      expect(encodings, hasLength(2));
+
+      final lowLayer = encodings![0];
+      expect(lowLayer.rid, 'q');
+      expect(lowLayer.scaleResolutionDownBy, 2);
+      expect(lowLayer.maxFramerate, 15);
+      expect(lowLayer.maxBitrate, 625000);
+      expect(lowLayer.priority, rtc.RTCPriorityType.high);
+      expect(lowLayer.networkPriority, rtc.RTCPriorityType.high);
+    });
   });
 }

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -87,5 +87,26 @@ void main() {
       expect(lowLayer.priority, rtc.RTCPriorityType.high);
       expect(lowLayer.networkPriority, rtc.RTCPriorityType.high);
     });
+
+    test('default lower layer follows selected screen share preset', () {
+      final encodings = Utils.computeVideoEncodings(
+        isScreenShare: true,
+        dimensions: const lk.VideoDimensions(1920, 1080),
+      );
+
+      expect(encodings, hasLength(2));
+
+      final lowLayer = encodings![0];
+      expect(lowLayer.rid, 'q');
+      expect(lowLayer.scaleResolutionDownBy, 2);
+      expect(lowLayer.maxFramerate, 15);
+      expect(lowLayer.maxBitrate, 625000);
+
+      final topLayer = encodings[1];
+      expect(topLayer.rid, 'h');
+      expect(topLayer.scaleResolutionDownBy, 1);
+      expect(topLayer.maxFramerate, 15);
+      expect(topLayer.maxBitrate, 2500000);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Align Flutter's generated default lower screen-share simulcast layer with the common SDK behavior.

This updates the default generated lower layer to:
- use half resolution
- keep the top layer's frame rate
- use `max(150kbps, topLayerBitrate / 4)`
- carry through explicit bitrate/network priorities

Also aligns the `screenShareH720FPS5` and `screenShareH1080FPS30` preset bitrates with the common SDK values.

## Notes

This does not add the JS-only screen-share presets such as `h360fps15`, `h720fps30`, or `original`; that broader preset parity work should be handled separately.

## Tests

- `dart format --set-exit-if-changed lib/src/types/video_parameters.dart lib/src/utils.dart test/utils_test.dart`
- `flutter test test/utils_test.dart`
- `flutter analyze --no-pub lib/src/types/video_parameters.dart lib/src/utils.dart test/utils_test.dart`