### PR TITLE
chore: fix Windows CI and tidy check names

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   dart-format-check:
-    name: Dart Format Check
+    name: Dart Format
     runs-on: ubuntu-latest
 
     steps:
@@ -35,7 +35,7 @@ jobs:
         run: dart format . --set-exit-if-changed
 
   import-sorter-check:
-    name: Import Sorter Check
+    name: Import Sorter
     runs-on: ubuntu-latest
 
     steps:
@@ -46,7 +46,7 @@ jobs:
         run: dart run import_sorter:main --no-comments --exit-if-changed
 
   version-consistency-check:
-    name: Version Consistency Check
+    name: Version Consistency
     runs-on: ubuntu-latest
 
     steps:
@@ -57,7 +57,7 @@ jobs:
         run: dart run scripts/check_version.dart
 
   dart-analyze-check:
-    name: Dart Analyze Check
+    name: Dart Analyze
     runs-on: ubuntu-latest
 
     steps:
@@ -68,7 +68,7 @@ jobs:
         run: flutter analyze
 
   dart-test-check:
-    name: Dart Test Check
+    name: Dart Test
     runs-on: ubuntu-latest
 
     steps:
@@ -79,7 +79,7 @@ jobs:
         run: flutter test
 
   build-for-android:
-    name: Build for Flutter Android
+    name: Android
     runs-on: ubuntu-latest
 
     steps:
@@ -93,7 +93,7 @@ jobs:
         run: flutter build apk
 
   build-for-ios:
-    name: Build for Flutter iOS
+    name: iOS
     runs-on: macos-latest
 
     steps:
@@ -112,7 +112,7 @@ jobs:
         run: flutter build ios --release --no-codesign
 
   build-for-windows:
-    name: Build for Flutter Windows
+    name: Windows
     runs-on: windows-latest
 
     steps:
@@ -124,7 +124,7 @@ jobs:
         run: flutter build windows --release
 
   build-for-macos:
-    name: Build for Flutter macOS
+    name: macOS
     runs-on: macos-latest
 
     steps:
@@ -136,7 +136,7 @@ jobs:
         run: flutter build macos --release
 
   build-for-linux:
-    name: Build for Flutter Linux
+    name: Linux
     runs-on: ubuntu-latest
 
     steps:
@@ -154,7 +154,7 @@ jobs:
         run: flutter build linux
 
   build-for-web:
-    name: Build for Flutter Web
+    name: Web
     runs-on: ubuntu-latest
 
     steps:
@@ -168,7 +168,7 @@ jobs:
         run: flutter build web
 
   build-for-web-wasm:
-    name: Build for Flutter Web WASM
+    name: Web WASM
     runs-on: ubuntu-latest
 
     steps:

--- a/example/windows/CMakeLists.txt
+++ b/example/windows/CMakeLists.txt
@@ -50,6 +50,11 @@ add_subdirectory("runner")
 # them to the application.
 include(flutter/generated_plugins.cmake)
 
+# VS 2026 treats C++/WinRT's experimental coroutine include as a hard error.
+if(TARGET permission_handler_windows_plugin)
+  target_compile_definitions(permission_handler_windows_plugin PRIVATE
+    _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+endif()
 
 # === Installation ===
 # Support files are copied into place next to the executable, so that it can


### PR DESCRIPTION
## Summary
- Suppress the C++/WinRT experimental coroutine deprecation error for `permission_handler_windows_plugin`.
- Keeps the example Windows build working on the `windows-2025-vs2026` GitHub Actions image.
- Shorten Build workflow job names so checks render as `Build / Android`, `Build / Dart Analyze`, etc.

## Testing
- `git diff --check`
- Parsed `.github/workflows/build.yaml` with Ruby YAML.
