### PR TITLE
chore(android): support AGP 9 built-in Kotlin

### DIFF
--- a/.changes/agp9-built-in-kotlin
+++ b/.changes/agp9-built-in-kotlin
@@ -1,0 +1,1 @@
+patch type="fixed" "Android plugin compatibility with AGP 9 built-in Kotlin"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group = "io.livekit.plugin"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = "1.8.22"
+    ext.kotlin_version = "2.1.0"
     repositories {
         google()
         mavenCentral()
@@ -22,7 +22,18 @@ allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+// AGP 9's built-in Kotlin compiles Kotlin itself and rejects the Kotlin Gradle
+// Plugin. Apply KGP only when built-in Kotlin is NOT active: that means AGP < 9,
+// or AGP 9 with android.builtInKotlin=false (the configuration Flutter currently
+// ships by default while the ecosystem migrates).
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize(".")[0] as int
+def builtInKotlinActive = agpMajor >= 9 &&
+    (!project.hasProperty("android.builtInKotlin") ||
+        Boolean.parseBoolean(project.property("android.builtInKotlin").toString()))
+if (!builtInKotlinActive) {
+    apply plugin: "kotlin-android"
+}
 
 android {
     if (project.android.hasProperty("namespace")) {
@@ -34,10 +45,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
     }
 
     sourceSets {
@@ -66,5 +73,21 @@ android {
                showStandardStreams = true
             }
         }
+    }
+}
+
+// Configure the Kotlin JVM target. The compilerOptions DSL requires KGP 1.9+ or
+// AGP 9 built-in Kotlin; older Flutter app templates ship KGP 1.8.x, which only
+// supports the legacy kotlinOptions DSL.
+def kotlinExt = project.extensions.findByName("kotlin")
+if (kotlinExt?.hasProperty("compilerOptions")) {
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+        }
+    }
+} else {
+    android.kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 }


### PR DESCRIPTION
## Summary

Migrates the Android plugin to AGP 9's built-in Kotlin while keeping older toolchains building (same pattern as flutter-webrtc/flutter-webrtc#2075):

- Apply the **Kotlin Gradle Plugin only when built-in Kotlin is inactive** — AGP < 9, or AGP 9 with `android.builtInKotlin=false` (the configuration Flutter currently ships by default while the ecosystem migrates). When AGP 9's built-in Kotlin is active it registers the `kotlin` extension itself and rejects KGP, so applying it is skipped.
- Set the JVM target through the `kotlin { compilerOptions {} }` DSL **when the extension supports it** (KGP 1.9+ / AGP 9 built-in Kotlin), falling back to the legacy `kotlinOptions` DSL for apps still on KGP 1.8.x.
- Bump the standalone buildscript fallback KGP to 2.1.0 so it is self-consistent.
- Add a changeset entry for the generated release notes.

## Context

AGP 9 uses built-in Kotlin support and rejects Android plugins that still apply KGP directly. This follows the Flutter compatibility migration path instead of raising the minimum supported toolchain.

## Verification

- Example app builds (`flutter build apk --debug`) on the current stable toolchain (AGP 8.x + modern KGP path).
- The AGP 9 built-in path mirrors the reviewed and merged flutter-webrtc implementation.