### PR TITLE
Use maintain-resolution as the default video degradation preference

### DIFF
--- a/.changes/video-degradation-default
+++ b/.changes/video-degradation-default
@@ -1,0 +1,1 @@
+patch type="fixed" "Use maintain-resolution as the default video degradation preference for local video publishing"

--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -386,10 +386,7 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
       }
 
       if ([TrackSource.camera, TrackSource.screenShareVideo].contains(track.source)) {
-        final degradationPreference = publishOptions.degradationPreference ??
-            getDefaultDegradationPreference(
-              track,
-            );
+        final degradationPreference = publishOptions.degradationPreference ?? DegradationPreference.maintainResolution;
         await track.setDegradationPreference(degradationPreference);
       }
 
@@ -487,10 +484,7 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
       }
 
       if ([TrackSource.camera, TrackSource.screenShareVideo].contains(track.source)) {
-        final degradationPreference = publishOptions.degradationPreference ??
-            getDefaultDegradationPreference(
-              track,
-            );
+        final degradationPreference = publishOptions.degradationPreference ?? DegradationPreference.maintainResolution;
         await track.setDegradationPreference(degradationPreference);
       }
 
@@ -591,17 +585,6 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
     }
 
     await pub.dispose();
-  }
-
-  DegradationPreference getDefaultDegradationPreference(LocalVideoTrack track) {
-    // a few of reasons we have different default paths:
-    // 1. without this, Chrome seems to aggressively resize the SVC video stating `quality-limitation: bandwidth` even when BW isn't an issue
-    // 2. since we are overriding contentHint to motion (to workaround L1T3 publishing), it overrides the default degradationPreference to `balanced`
-    final VideoDimensions dimensions = track.currentOptions.params.dimensions;
-    if (track.source == TrackSource.screenShareVideo || dimensions.height >= 1080) {
-      return DegradationPreference.maintainResolution;
-    }
-    return DegradationPreference.balanced;
   }
 
   /// Convenience method to unpublish all tracks.


### PR DESCRIPTION
## Summary
- Align Flutter default local-video degradation behavior with the Swift SDK.
- Default unset `VideoPublishOptions.degradationPreference` to `maintainResolution` for camera and screen-share publishing.
- Keep explicit degradation preferences overrideable by apps.

## Context
Related to #1097, which explores preserving video quality through a live-streaming option. This PR takes the smaller SDK-default approach instead: use maintain-resolution by default, matching Swift, without adding a separate app-facing toggle for this behavior.

## Testing
- `dart analyze`
- `flutter test test/core/room_e2e_test.dart`