### PR TITLE
feat: VideoTrackRender.placeholderBuilder

### DIFF
--- a/.changes/track-render-placeholder
+++ b/.changes/track-render-placeholder
@@ -1,0 +1,1 @@
+minor type="added" "Widget Placeholder added for VideoTrackRenderer"

--- a/lib/src/widgets/video_track_renderer.dart
+++ b/lib/src/widgets/video_track_renderer.dart
@@ -76,6 +76,11 @@ class VideoTrackRenderer extends StatefulWidget {
   /// ratio), avoiding an under-sized layer on retina / high-density displays.
   final AdaptiveStreamPixelDensity adaptiveStreamPixelDensity;
 
+  /// Placeholder widget to display while the track is loading.
+  ///
+  /// This has no effect if [renderMode] is [VideoRenderMode.platformView].
+  final WidgetBuilder? placeholderBuilder;
+
   const VideoTrackRenderer(
     this.track, {
     this.fit = VideoViewFit.contain,
@@ -85,6 +90,7 @@ class VideoTrackRenderer extends StatefulWidget {
     this.cachedRenderer,
     this.autoCenter = true,
     this.adaptiveStreamPixelDensity = AdaptiveStreamPixelDensity.auto,
+    this.placeholderBuilder,
     Key? key,
   }) : super(key: key);
 
@@ -224,6 +230,7 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
               mirror: _shouldMirror(),
               filterQuality: FilterQuality.medium,
               objectFit: widget.fit.toRTCType(),
+              placeholderBuilder: widget.placeholderBuilder,
             );
           },
         );
@@ -245,6 +252,7 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
       mirror: _shouldMirror(),
       filterQuality: FilterQuality.medium,
       objectFit: widget.fit.toRTCType(),
+      placeholderBuilder: widget.placeholderBuilder,
     );
   }
 

--- a/lib/src/widgets/video_track_renderer.dart
+++ b/lib/src/widgets/video_track_renderer.dart
@@ -76,9 +76,9 @@ class VideoTrackRenderer extends StatefulWidget {
   /// ratio), avoiding an under-sized layer on retina / high-density displays.
   final AdaptiveStreamPixelDensity adaptiveStreamPixelDensity;
 
-  /// Placeholder widget to display while the track is loading.
+  /// Placeholder builder to display while the track is loading.
   ///
-  /// This has no effect if [renderMode] is [VideoRenderMode.platformView].
+  /// On iOS, this has no effect when [renderMode] is [VideoRenderMode.platformView].
   final WidgetBuilder? placeholderBuilder;
 
   const VideoTrackRenderer(
@@ -217,7 +217,7 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
   }
 
   Widget _videoViewForWeb() => !_rendererReadyForWeb
-      ? Container()
+      ? (widget.placeholderBuilder?.call(context) ?? const SizedBox.shrink())
       : Builder(
           key: _viewRegistration.key,
           builder: (ctx) {
@@ -289,7 +289,7 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
             },
           );
         }
-        return Container();
+        return widget.placeholderBuilder?.call(context) ?? const SizedBox.shrink();
       });
 
   // FutureBuilder will cause flickering for flutter web. so using


### PR DESCRIPTION
Fixes #1061

Example usage:
```dart
VideoTrackRenderer(
  ...,
  placeholderBuilder: (context) {
    return const CircularProgressIndicator.adaptive();
  },
)
```