### PR TITLE
feat: add deployment field to agent dispatch

### DIFF
--- a/lib/src/token_source/room_configuration.dart
+++ b/lib/src/token_source/room_configuration.dart
@@ -26,9 +26,13 @@ class RoomAgentDispatch {
   /// Metadata for the agent.
   final String? metadata;
 
+  /// Optional deployment to target. Leave empty to target the production deployment.
+  final String? deployment;
+
   const RoomAgentDispatch({
     this.agentName,
     this.metadata,
+    this.deployment,
   });
 
   factory RoomAgentDispatch.fromJson(Map<String, dynamic> json) => _$RoomAgentDispatchFromJson(json);

--- a/lib/src/token_source/room_configuration.g.dart
+++ b/lib/src/token_source/room_configuration.g.dart
@@ -9,11 +9,13 @@ part of 'room_configuration.dart';
 RoomAgentDispatch _$RoomAgentDispatchFromJson(Map<String, dynamic> json) => RoomAgentDispatch(
       agentName: json['agent_name'] as String?,
       metadata: json['metadata'] as String?,
+      deployment: json['deployment'] as String?,
     );
 
 Map<String, dynamic> _$RoomAgentDispatchToJson(RoomAgentDispatch instance) => <String, dynamic>{
       if (instance.agentName case final value?) 'agent_name': value,
       if (instance.metadata case final value?) 'metadata': value,
+      if (instance.deployment case final value?) 'deployment': value,
     };
 
 RoomConfiguration _$RoomConfigurationFromJson(Map<String, dynamic> json) => RoomConfiguration(

--- a/lib/src/token_source/token_source.dart
+++ b/lib/src/token_source/token_source.dart
@@ -43,6 +43,9 @@ class TokenRequestOptions {
   /// Metadata passed to the agent job.
   final String? agentMetadata;
 
+  /// Optional deployment to target. Leave empty to target the production deployment.
+  final String? agentDeployment;
+
   const TokenRequestOptions({
     this.roomName,
     this.participantName,
@@ -51,6 +54,7 @@ class TokenRequestOptions {
     this.participantAttributes,
     this.agentName,
     this.agentMetadata,
+    this.agentDeployment,
   });
 
   factory TokenRequestOptions.fromJson(Map<String, dynamic> json) => _$TokenRequestOptionsFromJson(json);
@@ -58,8 +62,8 @@ class TokenRequestOptions {
 
   /// Converts this options object to a wire-format request.
   TokenSourceRequest toRequest() {
-    final List<RoomAgentDispatch>? agents = (agentName != null || agentMetadata != null)
-        ? [RoomAgentDispatch(agentName: agentName, metadata: agentMetadata)]
+    final List<RoomAgentDispatch>? agents = (agentName != null || agentMetadata != null || agentDeployment != null)
+        ? [RoomAgentDispatch(agentName: agentName, metadata: agentMetadata, deployment: agentDeployment)]
         : null;
 
     return TokenSourceRequest(
@@ -83,6 +87,7 @@ class TokenRequestOptions {
         other.participantMetadata == participantMetadata &&
         other.agentName == agentName &&
         other.agentMetadata == agentMetadata &&
+        other.agentDeployment == agentDeployment &&
         const MapEquality().equals(other.participantAttributes, participantAttributes);
   }
 
@@ -95,6 +100,7 @@ class TokenRequestOptions {
       participantMetadata,
       agentName,
       agentMetadata,
+      agentDeployment,
       const MapEquality().hash(participantAttributes),
     );
   }

--- a/lib/src/token_source/token_source.g.dart
+++ b/lib/src/token_source/token_source.g.dart
@@ -16,6 +16,7 @@ TokenRequestOptions _$TokenRequestOptionsFromJson(Map<String, dynamic> json) => 
       ),
       agentName: json['agentName'] as String?,
       agentMetadata: json['agentMetadata'] as String?,
+      agentDeployment: json['agentDeployment'] as String?,
     );
 
 Map<String, dynamic> _$TokenRequestOptionsToJson(TokenRequestOptions instance) => <String, dynamic>{
@@ -26,6 +27,7 @@ Map<String, dynamic> _$TokenRequestOptionsToJson(TokenRequestOptions instance) =
       if (instance.participantAttributes case final value?) 'participantAttributes': value,
       if (instance.agentName case final value?) 'agentName': value,
       if (instance.agentMetadata case final value?) 'agentMetadata': value,
+      if (instance.agentDeployment case final value?) 'agentDeployment': value,
     };
 
 TokenSourceRequest _$TokenSourceRequestFromJson(Map<String, dynamic> json) => TokenSourceRequest(


### PR DESCRIPTION
## Summary
- Add `deployment` field to `RoomAgentDispatch` for targeting specific agent deployments
- Add `agentDeployment` to `TokenRequestOptions` to pass deployment through token requests
- Update generated JSON serialization code

The `deployment` field allows targeting a specific agent deployment (e.g., "staging"). Leave empty to target the production deployment.

Related PRs:
- node-sdks: https://github.com/livekit/node-sdks/pull/675
- python-sdks: https://github.com/livekit/python-sdks/pull/722
- rust-sdks: https://github.com/livekit/rust-sdks/pull/1176
- client-sdk-swift: https://github.com/livekit/client-sdk-swift/pull/1043
- client-sdk-js: https://github.com/livekit/client-sdk-js/pull/1971

## Usage
```dart
final options = TokenRequestOptions(
  roomName: 'my-room',
  agentName: 'my-agent',
  agentDeployment: 'staging',  // Optional: target specific deployment
);
```

Or directly via `RoomAgentDispatch`:
```dart
final dispatch = RoomAgentDispatch(
  agentName: 'my-agent',
  metadata: 'my-metadata',
  deployment: 'staging',
);
```

## Test plan

### Unit Tests
```bash
flutter test
flutter test test/token/token_source_test.dart -v
```

### Manual Verification

**1. Verify JSON serialization includes deployment:**
```dart
final dispatch = RoomAgentDispatch(
  agentName: 'my-agent',
  deployment: 'staging',
);
final json = dispatch.toJson();
print(json);  // Should include 'deployment': 'staging'
```

**2. Verify TokenRequestOptions converts to request correctly:**
```dart
final options = TokenRequestOptions(
  roomName: 'test-room',
  agentName: 'my-agent',
  agentDeployment: 'staging',
);
final request = options.toRequest();
print(request.roomConfiguration?.agents?.first?.deployment);  // Should print 'staging'
```

**3. Verify JSON round-trip:**
```dart
final original = RoomAgentDispatch(
  agentName: 'my-agent',
  deployment: 'staging',
);
final json = original.toJson();
final restored = RoomAgentDispatch.fromJson(json);
assert(restored.deployment == 'staging');
```

### End-to-End Verification
1. Use TokenSource to get credentials with agentDeployment set
2. Connect to room - agent with matching deployment should join
3. Verify only staging agent receives the dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)