### PR TITLE
Apply audio processing options when local capture starts

### DIFF
--- a/.changes/audio-processing-create-cleanup
+++ b/.changes/audio-processing-create-cleanup
@@ -1,0 +1,1 @@
+patch type="fixed" "Stop local audio tracks when create-time audio processing setup fails"

--- a/.changes/audio-processing-create-cleanup
+++ b/.changes/audio-processing-create-cleanup
@@ -1,1 +1,1 @@
-patch type="fixed" "Stop local audio tracks when create-time audio processing setup fails"
+patch type="fixed" "Stop local audio tracks when recording start fails"

--- a/.changes/audio-processing-create-cleanup
+++ b/.changes/audio-processing-create-cleanup
@@ -1,1 +1,1 @@
-patch type="fixed" "Stop local audio tracks when recording start fails"
+patch type="fixed" "Clean up local audio tracks when recording start fails"

--- a/.changes/audio-processing-platform-gate
+++ b/.changes/audio-processing-platform-gate
@@ -1,1 +1,1 @@
-patch type="fixed" "Throw a typed platform-unavailable exception when runtime audio processing options are unsupported"
+patch type="fixed" "Throw platformUnavailable when runtime audio processing is unsupported"

--- a/.changes/audio-processing-platform-gate
+++ b/.changes/audio-processing-platform-gate
@@ -1,0 +1,1 @@
+patch type="fixed" "Return a typed platform-unavailable result when runtime audio processing options are unsupported"

--- a/.changes/audio-processing-platform-gate
+++ b/.changes/audio-processing-platform-gate
@@ -1,1 +1,1 @@
-patch type="fixed" "Return a typed platform-unavailable result when runtime audio processing options are unsupported"
+patch type="fixed" "Throw a typed platform-unavailable exception when runtime audio processing options are unsupported"

--- a/.changes/audio-processing-start-flow
+++ b/.changes/audio-processing-start-flow
@@ -1,0 +1,1 @@
+patch type="fixed" "Apply create-time audio processing when local recording starts"

--- a/.changes/audio-processing-start-flow
+++ b/.changes/audio-processing-start-flow
@@ -1,1 +1,1 @@
-patch type="fixed" "Apply create-time audio processing when local recording starts"
+patch type="fixed" "Apply create-time audio processing when local recording is prepared"

--- a/.changes/runtime-audio-options
+++ b/.changes/runtime-audio-options
@@ -1,1 +1,1 @@
-minor type="added" "Runtime audio processing options for local audio tracks and engine-wide audio processing state read-back on AudioManager"
+minor type="added" "Runtime audio processing controls for local audio tracks"

--- a/android/src/main/kotlin/io/livekit/plugin/LiveKitPlugin.kt
+++ b/android/src/main/kotlin/io/livekit/plugin/LiveKitPlugin.kt
@@ -274,7 +274,7 @@ class LiveKitPlugin : FlutterPlugin, MethodCallHandler {
   private fun audioProcessingResultCodeString(code: AudioProcessingOptionsResult.Code): String = when (code) {
     AudioProcessingOptionsResult.Code.APPLIED -> "applied"
     AudioProcessingOptionsResult.Code.STORED -> "stored"
-    AudioProcessingOptionsResult.Code.REJECTED_REMOTE_TRACK -> "rejectedRemoteTrack"
+    AudioProcessingOptionsResult.Code.REJECTED_REMOTE_TRACK -> "applyFailed"
     AudioProcessingOptionsResult.Code.REJECTED_INVALID_COMBINATION -> "rejectedInvalidCombination"
     AudioProcessingOptionsResult.Code.REJECTED_PLATFORM_UNAVAILABLE -> "rejectedPlatformUnavailable"
     AudioProcessingOptionsResult.Code.APPLY_FAILED -> "applyFailed"

--- a/android/src/main/kotlin/io/livekit/plugin/LiveKitPlugin.kt
+++ b/android/src/main/kotlin/io/livekit/plugin/LiveKitPlugin.kt
@@ -66,7 +66,7 @@ class LiveKitPlugin : FlutterPlugin, MethodCallHandler {
     channel.setMethodCallHandler(this)
     binaryMessenger = flutterPluginBinding.binaryMessenger
     audioSwitchManager = LKAudioSwitchManager(flutterPluginBinding.applicationContext)
-    audioDeviceModuleExecutor?.shutdownNow()
+    audioDeviceModuleExecutor?.shutdown()
     audioDeviceModuleExecutor = Executors.newSingleThreadExecutor()
   }
 
@@ -472,7 +472,7 @@ class LiveKitPlugin : FlutterPlugin, MethodCallHandler {
     audioSwitchManager?.dispose()
     audioSwitchManager = null
 
-    audioDeviceModuleExecutor?.shutdownNow()
+    audioDeviceModuleExecutor?.shutdown()
     audioDeviceModuleExecutor = null
 
     // Cleanup all processors

--- a/android/src/main/kotlin/io/livekit/plugin/LiveKitPlugin.kt
+++ b/android/src/main/kotlin/io/livekit/plugin/LiveKitPlugin.kt
@@ -39,7 +39,9 @@ import org.webrtc.audio.AudioProcessingMode
 import org.webrtc.audio.AudioProcessingOptions
 import org.webrtc.audio.AudioProcessingOptionsResult
 import org.webrtc.audio.AudioProcessingState
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
 
 /** LiveKitPlugin */
 class LiveKitPlugin : FlutterPlugin, MethodCallHandler {
@@ -47,7 +49,7 @@ class LiveKitPlugin : FlutterPlugin, MethodCallHandler {
   private var flutterWebRTCPlugin = FlutterWebRTCPlugin.sharedSingleton
   private var binaryMessenger: BinaryMessenger? = null
   private var audioSwitchManager: LKAudioSwitchManager? = null
-  private val audioDeviceModuleExecutor = Executors.newSingleThreadExecutor()
+  private var audioDeviceModuleExecutor: ExecutorService? = null
   private val mainHandler = Handler(Looper.getMainLooper())
 
   /// The MethodChannel that will the communication between Flutter and native Android
@@ -64,6 +66,8 @@ class LiveKitPlugin : FlutterPlugin, MethodCallHandler {
     channel.setMethodCallHandler(this)
     binaryMessenger = flutterPluginBinding.binaryMessenger
     audioSwitchManager = LKAudioSwitchManager(flutterPluginBinding.applicationContext)
+    audioDeviceModuleExecutor?.shutdownNow()
+    audioDeviceModuleExecutor = Executors.newSingleThreadExecutor()
   }
 
   @SuppressLint("SuspiciousIndentation")
@@ -259,18 +263,26 @@ class LiveKitPlugin : FlutterPlugin, MethodCallHandler {
       return
     }
 
+    val executor = audioDeviceModuleExecutorOrError(result, "rejectedPlatformUnavailable") ?: return
     val options = audioProcessingOptions(call)
-    audioDeviceModuleExecutor.execute {
-      try {
-        audioDeviceModule.prewarmRecording(options)
-        mainHandler.post {
-          result.success(null)
-        }
-      } catch (error: Throwable) {
-        mainHandler.post {
-          result.error("applyFailed", error.message, null)
+    try {
+      executor.execute {
+        try {
+          // prewarmRecording applies Android platform AP and prepares recording
+          // without setting the client-start flag. WebRTC exposes this as void,
+          // so only thrown failures can be surfaced here.
+          audioDeviceModule.prewarmRecording(options)
+          mainHandler.post {
+            result.success(null)
+          }
+        } catch (error: Throwable) {
+          mainHandler.post {
+            result.error("applyFailed", error.message, null)
+          }
         }
       }
+    } catch (error: RejectedExecutionException) {
+      result.error("rejectedPlatformUnavailable", "audio device module executor is unavailable", null)
     }
   }
 
@@ -281,18 +293,32 @@ class LiveKitPlugin : FlutterPlugin, MethodCallHandler {
       return
     }
 
-    audioDeviceModuleExecutor.execute {
-      try {
-        audioDeviceModule.requestStopRecording()
-        mainHandler.post {
-          result.success(null)
-        }
-      } catch (error: Throwable) {
-        mainHandler.post {
-          result.error("stopLocalRecording", error.message, null)
+    val executor = audioDeviceModuleExecutorOrError(result, "stopLocalRecording") ?: return
+    try {
+      executor.execute {
+        try {
+          audioDeviceModule.requestStopRecording()
+          mainHandler.post {
+            result.success(null)
+          }
+        } catch (error: Throwable) {
+          mainHandler.post {
+            result.error("stopLocalRecording", error.message, null)
+          }
         }
       }
+    } catch (error: RejectedExecutionException) {
+      result.error("stopLocalRecording", "audio device module executor is unavailable", null)
     }
+  }
+
+  private fun audioDeviceModuleExecutorOrError(result: Result, code: String): ExecutorService? {
+    val executor = audioDeviceModuleExecutor
+    if (executor == null || executor.isShutdown) {
+      result.error(code, "audio device module executor is unavailable", null)
+      return null
+    }
+    return executor
   }
 
   private fun audioProcessingOptions(call: MethodCall): AudioProcessingOptions =
@@ -445,6 +471,9 @@ class LiveKitPlugin : FlutterPlugin, MethodCallHandler {
 
     audioSwitchManager?.dispose()
     audioSwitchManager = null
+
+    audioDeviceModuleExecutor?.shutdownNow()
+    audioDeviceModuleExecutor = null
 
     // Cleanup all processors
     audioProcessors.values.forEach { it.cleanup() }

--- a/android/src/main/kotlin/io/livekit/plugin/LiveKitPlugin.kt
+++ b/android/src/main/kotlin/io/livekit/plugin/LiveKitPlugin.kt
@@ -274,7 +274,7 @@ class LiveKitPlugin : FlutterPlugin, MethodCallHandler {
   private fun audioProcessingResultCodeString(code: AudioProcessingOptionsResult.Code): String = when (code) {
     AudioProcessingOptionsResult.Code.APPLIED -> "applied"
     AudioProcessingOptionsResult.Code.STORED -> "stored"
-    AudioProcessingOptionsResult.Code.REJECTED_REMOTE_TRACK -> "applyFailed"
+    AudioProcessingOptionsResult.Code.REJECTED_REMOTE_TRACK -> "unknown"
     AudioProcessingOptionsResult.Code.REJECTED_INVALID_COMBINATION -> "rejectedInvalidCombination"
     AudioProcessingOptionsResult.Code.REJECTED_PLATFORM_UNAVAILABLE -> "rejectedPlatformUnavailable"
     AudioProcessingOptionsResult.Code.APPLY_FAILED -> "applyFailed"

--- a/android/src/main/kotlin/io/livekit/plugin/LiveKitPlugin.kt
+++ b/android/src/main/kotlin/io/livekit/plugin/LiveKitPlugin.kt
@@ -17,6 +17,8 @@
 package io.livekit.plugin
 
 import android.annotation.SuppressLint
+import android.os.Handler
+import android.os.Looper
 import androidx.annotation.NonNull
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -37,6 +39,7 @@ import org.webrtc.audio.AudioProcessingMode
 import org.webrtc.audio.AudioProcessingOptions
 import org.webrtc.audio.AudioProcessingOptionsResult
 import org.webrtc.audio.AudioProcessingState
+import java.util.concurrent.Executors
 
 /** LiveKitPlugin */
 class LiveKitPlugin : FlutterPlugin, MethodCallHandler {
@@ -44,6 +47,8 @@ class LiveKitPlugin : FlutterPlugin, MethodCallHandler {
   private var flutterWebRTCPlugin = FlutterWebRTCPlugin.sharedSingleton
   private var binaryMessenger: BinaryMessenger? = null
   private var audioSwitchManager: LKAudioSwitchManager? = null
+  private val audioDeviceModuleExecutor = Executors.newSingleThreadExecutor()
+  private val mainHandler = Handler(Looper.getMainLooper())
 
   /// The MethodChannel that will the communication between Flutter and native Android
   ///
@@ -236,7 +241,62 @@ class LiveKitPlugin : FlutterPlugin, MethodCallHandler {
       return
     }
 
-    val options = AudioProcessingOptions(
+    val options = audioProcessingOptions(call)
+    val processingResult = mediaTrack.setAudioProcessingOptions(options)
+    result.success(
+      mapOf(
+        "result" to processingResult.isSuccess,
+        "code" to audioProcessingResultCodeString(processingResult.code),
+        "message" to processingResult.message,
+      ),
+    )
+  }
+
+  private fun handleStartLocalRecording(call: MethodCall, result: Result) {
+    val audioDeviceModule = flutterWebRTCPlugin.audioDeviceModule
+    if (audioDeviceModule == null) {
+      result.error("rejectedPlatformUnavailable", "audio device module is unavailable", null)
+      return
+    }
+
+    val options = audioProcessingOptions(call)
+    audioDeviceModuleExecutor.execute {
+      try {
+        audioDeviceModule.prewarmRecording(options)
+        mainHandler.post {
+          result.success(null)
+        }
+      } catch (error: Throwable) {
+        mainHandler.post {
+          result.error("applyFailed", error.message, null)
+        }
+      }
+    }
+  }
+
+  private fun handleStopLocalRecording(result: Result) {
+    val audioDeviceModule = flutterWebRTCPlugin.audioDeviceModule
+    if (audioDeviceModule == null) {
+      result.error("stopLocalRecording", "audio device module is unavailable", null)
+      return
+    }
+
+    audioDeviceModuleExecutor.execute {
+      try {
+        audioDeviceModule.requestStopRecording()
+        mainHandler.post {
+          result.success(null)
+        }
+      } catch (error: Throwable) {
+        mainHandler.post {
+          result.error("stopLocalRecording", error.message, null)
+        }
+      }
+    }
+  }
+
+  private fun audioProcessingOptions(call: MethodCall): AudioProcessingOptions =
+    AudioProcessingOptions(
       AudioProcessingComponentOptions(
         call.argument<Boolean>("echoCancellation") ?: true,
         audioProcessingMode(call.argument<String>("echoCancellationMode")),
@@ -254,16 +314,6 @@ class LiveKitPlugin : FlutterPlugin, MethodCallHandler {
         audioProcessingMode(call.argument<String>("highPassFilterMode")),
       ),
     )
-
-    val processingResult = mediaTrack.setAudioProcessingOptions(options)
-    result.success(
-      mapOf(
-        "result" to processingResult.isSuccess,
-        "code" to audioProcessingResultCodeString(processingResult.code),
-        "message" to processingResult.message,
-      ),
-    )
-  }
 
   private fun audioProcessingMode(value: String?): AudioProcessingMode = when (value) {
     "platform" -> AudioProcessingMode.PLATFORM
@@ -350,6 +400,14 @@ class LiveKitPlugin : FlutterPlugin, MethodCallHandler {
 
       "setAudioProcessingOptions" -> {
         handleSetAudioProcessingOptions(call, result)
+      }
+
+      "startLocalRecording" -> {
+        handleStartLocalRecording(call, result)
+      }
+
+      "stopLocalRecording" -> {
+        handleStopLocalRecording(result)
       }
 
       "getAudioProcessingState" -> {

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -108,13 +108,26 @@ final now = AudioManager.instance.audioEngineState;
 
 Session management is one half of the audio stack. The other half is audio processing, the signal processing applied to captured audio such as echo cancellation, noise suppression, auto gain control, and the high pass filter. `AudioManager` is the home for both, and they compose cleanly.
 
-The session intent decides how the platform treats audio. Processing options decide what happens to captured local microphone audio:
+The session intent decides how the platform treats audio. Capture options decide what happens to local microphone audio:
 
 - A call usually uses the automatic `communication` session. The default `AudioCaptureOptions` enable echo cancellation, noise suppression, and auto gain control, while leaving the high pass filter off.
 - Use `AudioProcessingOptions.communication()` when you want all four voice filters on for an existing local audio track.
 - Use `AudioProcessingOptions.noProcessing()` for local capture where you want minimal processing, such as high quality recording or app-managed audio effects.
 
-Processing is applied per local audio track. `setAudioProcessingOptions` returns when the native layer applies or stores the options. If the request is invalid, unsupported, or cannot be applied, it throws `AudioProcessingException` and the track keeps its previous processing options.
+Create-time processing is configured through `AudioCaptureOptions`. `LocalAudioTrack.create(...)` stores these options, and LiveKit prepares them when local recording starts, such as during publish or preconnect. If the exposed native platform API reports that capture-time setup failed, the start path throws `AudioProcessingException` before publish creates a server-side publication.
+
+```dart
+final track = await LocalAudioTrack.create(
+  const AudioCaptureOptions(
+    echoCancellation: true,
+    noiseSuppression: true,
+    autoGainControl: true,
+    highPassFilter: false,
+  ),
+);
+```
+
+For an existing local audio track, call `setAudioProcessingOptions`. It returns when the native layer applies or stores the options. If the request is invalid, unsupported, or cannot be applied, it throws `AudioProcessingException` and the track keeps its previous processing options.
 
 ```dart
 try {

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -114,19 +114,15 @@ The session intent decides how the platform treats audio. Processing options dec
 - Use `AudioProcessingOptions.communication()` when you want all four voice filters on for an existing local audio track.
 - Use `AudioProcessingOptions.noProcessing()` for local capture where you want minimal processing, such as high quality recording or app-managed audio effects.
 
-Processing is applied per local audio track. A malformed request, such as an incompatible mode combination, throws `AudioProcessingException`. A request the platform could not honor comes back as an unsuccessful `AudioProcessingApplyResult` instead. This includes platforms where LiveKit is available but runtime audio processing is not implemented. When the result is unsuccessful, the track keeps its previous processing options.
+Processing is applied per local audio track. `setAudioProcessingOptions` returns when the native layer applies or stores the options. If the request is invalid, unsupported, or cannot be applied, it throws `AudioProcessingException` and the track keeps its previous processing options.
 
 ```dart
 try {
-  final result = await localAudioTrack.setAudioProcessingOptions(
+  await localAudioTrack.setAudioProcessingOptions(
     const AudioProcessingOptions.noProcessing(),
   );
-  if (!result.isSuccess) {
-    // For example: rejectedPlatformUnavailable on unsupported platforms.
-    print('audio processing not applied: ${result.code.value} ${result.message}');
-  }
 } on AudioProcessingException catch (error) {
-  print('invalid audio processing request: ${error.code.value} ${error.message}');
+  print('audio processing not applied: ${error.reason.name} ${error.message}');
 }
 ```
 

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -114,7 +114,7 @@ The session intent decides how the platform treats audio. Processing options dec
 - Use `AudioProcessingOptions.communication()` when you want all four voice filters on for an existing local audio track.
 - Use `AudioProcessingOptions.noProcessing()` for local capture where you want minimal processing, such as high quality recording or app-managed audio effects.
 
-Processing is applied per local audio track. A malformed request, such as an incompatible mode combination or a remote track, throws `AudioProcessingException`. A request the platform could not honor comes back as an unsuccessful `AudioProcessingApplyResult` instead. This includes platforms where LiveKit is available but runtime audio processing is not implemented. When the result is unsuccessful, the track keeps its previous processing options.
+Processing is applied per local audio track. A malformed request, such as an incompatible mode combination, throws `AudioProcessingException`. A request the platform could not honor comes back as an unsuccessful `AudioProcessingApplyResult` instead. This includes platforms where LiveKit is available but runtime audio processing is not implemented. When the result is unsuccessful, the track keeps its previous processing options.
 
 ```dart
 try {

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -114,7 +114,7 @@ The session intent decides how the platform treats audio. Processing options dec
 - Use `AudioProcessingOptions.communication()` when you want all four voice filters on for an existing local audio track.
 - Use `AudioProcessingOptions.noProcessing()` for local capture where you want minimal processing, such as high quality recording or app-managed audio effects.
 
-Processing is applied per local audio track. A malformed request (an incompatible mode, or a remote track) throws, while a request the platform could not honor comes back as an unsuccessful result:
+Processing is applied per local audio track. A malformed request, such as an incompatible mode combination or a remote track, throws `AudioProcessingException`. A request the platform could not honor comes back as an unsuccessful `AudioProcessingApplyResult` instead. This includes platforms where LiveKit is available but runtime audio processing is not implemented. When the result is unsuccessful, the track keeps its previous processing options.
 
 ```dart
 try {
@@ -122,6 +122,7 @@ try {
     const AudioProcessingOptions.noProcessing(),
   );
   if (!result.isSuccess) {
+    // For example: rejectedPlatformUnavailable on unsupported platforms.
     print('audio processing not applied: ${result.code.value} ${result.message}');
   }
 } on AudioProcessingException catch (error) {

--- a/lib/src/audio/audio_manager.dart
+++ b/lib/src/audio/audio_manager.dart
@@ -291,8 +291,8 @@ class AudioManager {
   ///
   /// The audio processing module is owned by the native peer connection factory
   /// and shared engine-wide, so this reflects what is actually applied across
-  /// the engine rather than any single track — use it to verify what a
-  /// `LocalAudioTrack.setAudioProcessingOptions` request resolved to. Returns
+  /// the engine rather than any single track. Use it to verify native state
+  /// after a `LocalAudioTrack.setAudioProcessingOptions` request. Returns
   /// `null` when the native side cannot provide it.
   Future<AudioProcessingState?> getAudioProcessingState() async {
     final response = await Native.getAudioProcessingState();

--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -179,80 +179,94 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
     final audioEncoding = publishOptions.encoding ?? AudioEncoding.presetMusic;
     final List<rtc.RTCRtpEncoding> encodings = [audioEncoding.toRTCRtpEncoding()];
 
-    final req = lk_rtc.AddTrackRequest(
-      cid: track.getCid(),
-      name: publishOptions.name ?? AudioPublishOptions.defaultMicrophoneName,
-      type: track.kind.toPBType(),
-      source: track.source.toPBType(),
-      muted: track.muted,
-      stream: buildStreamId(publishOptions, track.source),
-      disableDtx: !publishOptions.dtx,
-      disableRed: room.e2eeManager != null ? true : publishOptions.red ?? true,
-      encryption: room.roomOptions.lkEncryptionType,
-    );
+    final shouldStopOnFailure = !track.isActive;
+    try {
+      // Start capture before signaling so create-time audio processing failures
+      // abort publish without creating a server-side publication.
+      await track.start();
 
-    // Populate audio features (e.g., TF_NO_DTX, TF_PRECONNECT_BUFFER)
-    req.audioFeatures.addAll([
-      if (!publishOptions.dtx) lk_models.AudioTrackFeature.TF_NO_DTX,
-      if (publishOptions.preConnect) lk_models.AudioTrackFeature.TF_PRECONNECT_BUFFER,
-    ]);
-
-    Future<lk_models.TrackInfo> negotiate() async {
-      track.transceiver = await room.engine.createTransceiverRTCRtpSender(track, publishOptions!, encodings);
-      await room.engine.negotiate();
-      return lk_models.TrackInfo();
-    }
-
-    late lk_models.TrackInfo trackInfo;
-    if (room.engine.enabledPublishCodecs?.isNotEmpty ?? false) {
-      final rets = await Future.wait<lk_models.TrackInfo>([room.engine.addTrack(req), negotiate()]);
-      trackInfo = rets[0];
-    } else {
-      trackInfo = await room.engine.addTrack(req);
-
-      final transceiverInit = rtc.RTCRtpTransceiverInit(
-        direction: rtc.TransceiverDirection.SendOnly,
-        sendEncodings: encodings,
-      );
-      // addTransceiver cannot pass in a kind parameter due to a bug in flutter-webrtc (web)
-      track.transceiver = await room.engine.publisher?.pc.addTransceiver(
-        track: track.mediaStreamTrack,
-        kind: rtc.RTCRtpMediaType.RTCRtpMediaTypeAudio,
-        init: transceiverInit,
+      final req = lk_rtc.AddTrackRequest(
+        cid: track.getCid(),
+        name: publishOptions.name ?? AudioPublishOptions.defaultMicrophoneName,
+        type: track.kind.toPBType(),
+        source: track.source.toPBType(),
+        muted: track.muted,
+        stream: buildStreamId(publishOptions, track.source),
+        disableDtx: !publishOptions.dtx,
+        disableRed: room.e2eeManager != null ? true : publishOptions.red ?? true,
+        encryption: room.roomOptions.lkEncryptionType,
       );
 
-      await room.engine.negotiate();
+      // Populate audio features (e.g., TF_NO_DTX, TF_PRECONNECT_BUFFER)
+      req.audioFeatures.addAll([
+        if (!publishOptions.dtx) lk_models.AudioTrackFeature.TF_NO_DTX,
+        if (publishOptions.preConnect) lk_models.AudioTrackFeature.TF_PRECONNECT_BUFFER,
+      ]);
+
+      Future<lk_models.TrackInfo> negotiate() async {
+        track.transceiver = await room.engine.createTransceiverRTCRtpSender(track, publishOptions!, encodings);
+        await room.engine.negotiate();
+        return lk_models.TrackInfo();
+      }
+
+      late lk_models.TrackInfo trackInfo;
+      if (room.engine.enabledPublishCodecs?.isNotEmpty ?? false) {
+        final rets = await Future.wait<lk_models.TrackInfo>([room.engine.addTrack(req), negotiate()]);
+        trackInfo = rets[0];
+      } else {
+        trackInfo = await room.engine.addTrack(req);
+
+        final transceiverInit = rtc.RTCRtpTransceiverInit(
+          direction: rtc.TransceiverDirection.SendOnly,
+          sendEncodings: encodings,
+        );
+        // addTransceiver cannot pass in a kind parameter due to a bug in flutter-webrtc (web)
+        track.transceiver = await room.engine.publisher?.pc.addTransceiver(
+          track: track.mediaStreamTrack,
+          kind: rtc.RTCRtpMediaType.RTCRtpMediaTypeAudio,
+          init: transceiverInit,
+        );
+
+        await room.engine.negotiate();
+      }
+
+      logger.fine('publishAudioTrack engine.addTrack response: ${trackInfo}');
+
+      track.lastPublishOptions = publishOptions;
+
+      final pub = LocalTrackPublication<LocalAudioTrack>(
+        participant: this,
+        info: trackInfo,
+        track: track,
+      );
+      addTrackPublication(pub);
+
+      // did publish
+      await track.onPublish();
+      await track.processor?.onPublish(room);
+
+      final listener = track.createListener();
+      listener.on((TrackEndedEvent event) async {
+        logger.fine('TrackEndedEvent: ${event.track}');
+        await removePublishedTrack(pub.sid);
+      });
+
+      [events, room.events].emit(LocalTrackPublishedEvent(
+        participant: this,
+        publication: pub,
+      ));
+
+      return pub;
+    } catch (error) {
+      if (shouldStopOnFailure) {
+        try {
+          await track.stop();
+        } catch (stopError) {
+          logger.warning('failed to stop audio track after publish failure: $stopError');
+        }
+      }
+      rethrow;
     }
-
-    logger.fine('publishAudioTrack engine.addTrack response: ${trackInfo}');
-
-    track.lastPublishOptions = publishOptions;
-
-    final pub = LocalTrackPublication<LocalAudioTrack>(
-      participant: this,
-      info: trackInfo,
-      track: track,
-    );
-    addTrackPublication(pub);
-
-    // did publish
-    await track.onPublish();
-    await track.processor?.onPublish(room);
-
-    final listener = track.createListener();
-    listener.on((TrackEndedEvent event) async {
-      logger.fine('TrackEndedEvent: ${event.track}');
-      await removePublishedTrack(pub.sid);
-    });
-
-    [events, room.events].emit(LocalTrackPublishedEvent(
-      participant: this,
-      publication: pub,
-    ));
-
-    await track.start();
-
-    return pub;
   }
 
   /// Publish a [LocalVideoTrack] to the [Room].

--- a/lib/src/preconnect/pre_connect_audio_buffer.dart
+++ b/lib/src/preconnect/pre_connect_audio_buffer.dart
@@ -14,9 +14,6 @@
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart' show kIsWeb;
-
-import 'package:flutter_webrtc/flutter_webrtc.dart' as webrtc;
 import 'package:uuid/uuid.dart';
 
 import '../audio/audio_frame_capture.dart';
@@ -25,6 +22,8 @@ import '../events.dart';
 import '../logger.dart';
 import '../participant/local.dart';
 import '../support/byte_ring_buffer.dart';
+import '../support/native.dart';
+import '../support/platform.dart';
 import '../support/reusable_completer.dart';
 import '../track/local/audio.dart';
 import '../types/data_stream.dart';
@@ -145,9 +144,16 @@ class PreConnectAudioBuffer {
       throw error;
     }
 
-    if (!kIsWeb) {
-      await webrtc.NativeAudioManagement.startLocalRecording();
-      _nativeRecordingStarted = true;
+    try {
+      await _localTrack!.start();
+      _nativeRecordingStarted = lkPlatformSupportsExplicitAudioRecordingStart();
+    } catch (error) {
+      logger.severe('[Preconnect audio] failed to start local recording: $error');
+      _onError?.call(error);
+      await stopRecording(withError: error);
+      await _localTrack?.stop();
+      _localTrack = null;
+      rethrow;
     }
 
     logger.info('startAudioRenderer result: $result');
@@ -212,7 +218,7 @@ class PreConnectAudioBuffer {
 
     // Only stop native recording on error, the room's mic track still uses it.
     if (withError != null && _nativeRecordingStarted) {
-      await webrtc.NativeAudioManagement.stopLocalRecording();
+      await Native.stopLocalRecording();
     }
 
     _nativeRecordingStarted = false;

--- a/lib/src/support/native.dart
+++ b/lib/src/support/native.dart
@@ -72,12 +72,13 @@ class Native {
   ///
   /// Resolved natively against the underlying WebRTC audio track owned by
   /// flutter_webrtc; [options] is the serialized [AudioProcessingOptions] map.
-  /// Returns the native result map (`result`/`code`/`message`) so the caller
-  /// can surface typed rejections. This plugin is registered on platforms that
-  /// do not implement runtime audio processing, so missing or explicitly
-  /// unimplemented hooks are normalized to `rejectedPlatformUnavailable`.
-  /// Other channel errors propagate because they indicate unexpected native
-  /// failures rather than an unsupported platform capability.
+  /// Returns the native result map (`result`/`code`/`message`) so the Dart
+  /// track API can translate native outcomes into typed exceptions.
+  /// This plugin is registered on platforms that do not implement runtime audio
+  /// processing, so missing or explicitly unimplemented hooks are normalized to
+  /// `rejectedPlatformUnavailable`. Other channel errors propagate because they
+  /// indicate unexpected native failures rather than an unsupported platform
+  /// capability.
   @internal
   static Future<Map<String, dynamic>> setAudioProcessingOptions(
     String trackId,

--- a/lib/src/support/native.dart
+++ b/lib/src/support/native.dart
@@ -14,7 +14,7 @@
 
 import 'dart:async';
 
-import 'package:flutter/services.dart' show MethodChannel, MethodCall;
+import 'package:flutter/services.dart' show MethodChannel, MethodCall, MissingPluginException, PlatformException;
 
 import 'package:meta/meta.dart';
 
@@ -73,24 +73,41 @@ class Native {
   /// Resolved natively against the underlying WebRTC audio track owned by
   /// flutter_webrtc; [options] is the serialized [AudioProcessingOptions] map.
   /// Returns the native result map (`result`/`code`/`message`) so the caller
-  /// can surface typed rejections. Channel errors propagate to the caller.
+  /// can surface typed rejections. Missing or explicitly unimplemented platform
+  /// hooks are converted to `rejectedPlatformUnavailable`; other channel errors
+  /// propagate to the caller.
   @internal
   static Future<Map<String, dynamic>> setAudioProcessingOptions(
     String trackId,
     Map<String, dynamic> options,
   ) async {
-    final response = await channel.invokeMethod<dynamic>(
-      'setAudioProcessingOptions',
-      <String, dynamic>{
-        'trackId': trackId,
-        ...options,
-      },
-    );
-    if (response is Map) {
-      return response.map((key, value) => MapEntry(key.toString(), value));
+    try {
+      final response = await channel.invokeMethod<dynamic>(
+        'setAudioProcessingOptions',
+        <String, dynamic>{
+          'trackId': trackId,
+          ...options,
+        },
+      );
+      if (response is Map) {
+        return response.map((key, value) => MapEntry(key.toString(), value));
+      }
+      return <String, dynamic>{};
+    } on MissingPluginException {
+      return _audioProcessingPlatformUnavailable();
+    } on PlatformException catch (error) {
+      if (error.code == 'Unimplemented') {
+        return _audioProcessingPlatformUnavailable();
+      }
+      rethrow;
     }
-    return <String, dynamic>{};
   }
+
+  static Map<String, dynamic> _audioProcessingPlatformUnavailable() => <String, dynamic>{
+        'result': false,
+        'code': 'rejectedPlatformUnavailable',
+        'message': 'Audio processing options are unavailable on this platform.',
+      };
 
   /// Reads the engine-wide audio processing state from the native peer
   /// connection factory. Returns `null` when unavailable (e.g. the factory

--- a/lib/src/support/native.dart
+++ b/lib/src/support/native.dart
@@ -115,6 +115,11 @@ class Native {
         'message': 'Audio processing options are unavailable on this platform.',
       };
 
+  static PlatformException _audioProcessingPlatformUnavailableException() => PlatformException(
+        code: 'rejectedPlatformUnavailable',
+        message: 'Audio processing options are unavailable on this platform.',
+      );
+
   /// Starts the native WebRTC audio device module recording path with the
   /// capture-time audio processing options for the local microphone track.
   @internal
@@ -126,12 +131,11 @@ class Native {
       );
     } on PlatformException catch (error) {
       if (error.code == 'Unimplemented') {
-        logger.warning('startLocalRecording is not implemented on this platform');
-        return;
+        throw _audioProcessingPlatformUnavailableException();
       }
       rethrow;
     } on MissingPluginException {
-      logger.warning('startLocalRecording is not available on this platform');
+      throw _audioProcessingPlatformUnavailableException();
     }
   }
 
@@ -145,7 +149,7 @@ class Native {
         logger.warning('stopLocalRecording is not implemented on this platform');
         return;
       }
-      rethrow;
+      logger.warning('stopLocalRecording did throw ${error.code}: ${error.message}');
     } on MissingPluginException {
       logger.warning('stopLocalRecording is not available on this platform');
     }

--- a/lib/src/support/native.dart
+++ b/lib/src/support/native.dart
@@ -73,9 +73,11 @@ class Native {
   /// Resolved natively against the underlying WebRTC audio track owned by
   /// flutter_webrtc; [options] is the serialized [AudioProcessingOptions] map.
   /// Returns the native result map (`result`/`code`/`message`) so the caller
-  /// can surface typed rejections. Missing or explicitly unimplemented platform
-  /// hooks are converted to `rejectedPlatformUnavailable`; other channel errors
-  /// propagate to the caller.
+  /// can surface typed rejections. This plugin is registered on platforms that
+  /// do not implement runtime audio processing, so missing or explicitly
+  /// unimplemented hooks are normalized to `rejectedPlatformUnavailable`.
+  /// Other channel errors propagate because they indicate unexpected native
+  /// failures rather than an unsupported platform capability.
   @internal
   static Future<Map<String, dynamic>> setAudioProcessingOptions(
     String trackId,
@@ -96,6 +98,9 @@ class Native {
     } on MissingPluginException {
       return _audioProcessingPlatformUnavailable();
     } on PlatformException catch (error) {
+      // Web registers the plugin but returns `Unimplemented` for methods it
+      // does not support. Treat only that narrow case like a missing native
+      // implementation; do not hide unrelated native/channel failures.
       if (error.code == 'Unimplemented') {
         return _audioProcessingPlatformUnavailable();
       }

--- a/lib/src/support/native.dart
+++ b/lib/src/support/native.dart
@@ -115,6 +115,42 @@ class Native {
         'message': 'Audio processing options are unavailable on this platform.',
       };
 
+  /// Starts the native WebRTC audio device module recording path with the
+  /// capture-time audio processing options for the local microphone track.
+  @internal
+  static Future<void> startLocalRecording(Map<String, dynamic> audioProcessingOptions) async {
+    try {
+      await channel.invokeMethod<void>(
+        'startLocalRecording',
+        audioProcessingOptions,
+      );
+    } on PlatformException catch (error) {
+      if (error.code == 'Unimplemented') {
+        logger.warning('startLocalRecording is not implemented on this platform');
+        return;
+      }
+      rethrow;
+    } on MissingPluginException {
+      logger.warning('startLocalRecording is not available on this platform');
+    }
+  }
+
+  /// Stops recording that was explicitly started through [startLocalRecording].
+  @internal
+  static Future<void> stopLocalRecording() async {
+    try {
+      await channel.invokeMethod<void>('stopLocalRecording', <String, dynamic>{});
+    } on PlatformException catch (error) {
+      if (error.code == 'Unimplemented') {
+        logger.warning('stopLocalRecording is not implemented on this platform');
+        return;
+      }
+      rethrow;
+    } on MissingPluginException {
+      logger.warning('stopLocalRecording is not available on this platform');
+    }
+  }
+
   /// Reads the engine-wide audio processing state from the native peer
   /// connection factory. Returns `null` when unavailable (e.g. the factory
   /// does not exist yet, or the platform cannot provide it).

--- a/lib/src/support/platform.dart
+++ b/lib/src/support/platform.dart
@@ -29,6 +29,9 @@ bool lkPlatformIsDesktop() => [
       PlatformType.linux,
     ].contains(lkPlatform());
 
+bool lkPlatformSupportsExplicitAudioRecordingStart() =>
+    !lkPlatformIsTest() && [PlatformType.iOS, PlatformType.macOS, PlatformType.android].contains(lkPlatform());
+
 bool lkPlatformSupportsE2EE() => lkE2EESupportedImplementation();
 
 bool lkPlatformIsTest() => lkPlatformIsTestImplementation();

--- a/lib/src/track/local/audio.dart
+++ b/lib/src/track/local/audio.dart
@@ -77,8 +77,8 @@ class LocalAudioTrack extends LocalTrack with AudioTrack, LocalAudioManagementMi
   AudioSenderStats? prevStats;
 
   @override
-  Future<void> onStarted() async {
-    await super.onStarted();
+  Future<void> startCapture() async {
+    await super.startCapture();
     if (lkPlatformSupportsExplicitAudioRecordingStart()) {
       try {
         // Match Swift: start the ADM before publishing so capture-time audio

--- a/lib/src/track/local/audio.dart
+++ b/lib/src/track/local/audio.dart
@@ -186,9 +186,13 @@ class LocalAudioTrack extends LocalTrack with AudioTrack, LocalAudioManagementMi
       if (options.processor != null) {
         await track.setProcessor(options.processor);
       }
-    } catch (_) {
-      await track.stop();
-      rethrow;
+    } catch (error, stackTrace) {
+      try {
+        await track.stop();
+      } catch (stopError) {
+        logger.warning('failed to stop audio track after processor setup failure: $stopError');
+      }
+      Error.throwWithStackTrace(error, stackTrace);
     }
 
     return track;

--- a/lib/src/track/local/audio.dart
+++ b/lib/src/track/local/audio.dart
@@ -72,8 +72,7 @@ class LocalAudioTrack extends LocalTrack with AudioTrack, LocalAudioManagementMi
 
     // Malformed requests are caller bugs, so surface them loudly rather than
     // as a silently-unsuccessful result.
-    if (code == track_options.AudioProcessingOptionsResultCode.rejectedInvalidCombination ||
-        code == track_options.AudioProcessingOptionsResultCode.rejectedRemoteTrack) {
+    if (code == track_options.AudioProcessingOptionsResultCode.rejectedInvalidCombination) {
       throw track_options.AudioProcessingException(
         code,
         message.isNotEmpty ? message : 'Unable to apply audio processing options',

--- a/lib/src/track/local/audio.dart
+++ b/lib/src/track/local/audio.dart
@@ -14,8 +14,9 @@
 
 import 'dart:async';
 
-import 'package:collection/collection.dart';
 import 'package:flutter/services.dart' show PlatformException;
+
+import 'package:collection/collection.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 import 'package:meta/meta.dart';
 

--- a/lib/src/track/local/audio.dart
+++ b/lib/src/track/local/audio.dart
@@ -15,6 +15,7 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
+import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
 import 'package:meta/meta.dart';
 
@@ -25,6 +26,7 @@ import '../../options.dart';
 import '../../stats/audio_source_stats.dart';
 import '../../stats/stats.dart';
 import '../../support/native.dart';
+import '../../support/platform.dart';
 import '../../types/other.dart';
 import '../audio_management.dart';
 import '../options.dart' as track_options;
@@ -73,6 +75,23 @@ class LocalAudioTrack extends LocalTrack with AudioTrack, LocalAudioManagementMi
   num? get currentBitrate => _currentBitrate;
 
   AudioSenderStats? prevStats;
+
+  @override
+  Future<void> onStarted() async {
+    await super.onStarted();
+    if (lkPlatformSupportsExplicitAudioRecordingStart()) {
+      try {
+        // Match Swift: start the ADM before publishing so capture-time audio
+        // processing options are applied before WebRTC opens the microphone.
+        await Native.startLocalRecording(currentOptions.processing.toMap());
+      } on PlatformException catch (error) {
+        throw track_options.AudioProcessingException(
+          _audioProcessingFailureReason(error.code),
+          error.message ?? '',
+        );
+      }
+    }
+  }
 
   @override
   Future<bool> monitorStats() async {
@@ -166,16 +185,6 @@ class LocalAudioTrack extends LocalTrack with AudioTrack, LocalAudioManagementMi
       if (options.processor != null) {
         await track.setProcessor(options.processor);
       }
-
-      // Per-component processing modes are not part of standard capture
-      // constraints; apply them through the native audio processing path.
-      final processing = options.processing;
-      if (processing.echoCancellationMode != track_options.AudioProcessingMode.automatic ||
-          processing.noiseSuppressionMode != track_options.AudioProcessingMode.automatic ||
-          processing.autoGainControlMode != track_options.AudioProcessingMode.automatic ||
-          processing.highPassFilterMode != track_options.AudioProcessingMode.automatic) {
-        await track.setAudioProcessingOptions(processing);
-      }
     } catch (_) {
       await track.stop();
       rethrow;
@@ -189,29 +198,18 @@ void _throwIfAudioProcessingFailed(Map<String, dynamic> response) {
   final code = response['code'] as String?;
   final message = (response['message'] as String?) ?? '';
 
+  final reason = _audioProcessingFailureReason(code);
   switch (code) {
     case 'applied':
     case 'stored':
       return;
     case 'rejectedInvalidCombination':
-      throw track_options.AudioProcessingException(
-        track_options.AudioProcessingFailureReason.invalidCombination,
-        message,
-      );
     case 'rejectedPlatformUnavailable':
-      throw track_options.AudioProcessingException(
-        track_options.AudioProcessingFailureReason.platformUnavailable,
-        message,
-      );
     case 'applyFailed':
-      throw track_options.AudioProcessingException(
-        track_options.AudioProcessingFailureReason.applyFailed,
-        message,
-      );
     case 'unknown':
     case 'rejectedRemoteTrack':
       throw track_options.AudioProcessingException(
-        track_options.AudioProcessingFailureReason.unknown,
+        reason,
         message,
       );
     default:
@@ -219,6 +217,19 @@ void _throwIfAudioProcessingFailed(Map<String, dynamic> response) {
         track_options.AudioProcessingFailureReason.unknown,
         _unknownAudioProcessingMessage(code, message),
       );
+  }
+}
+
+track_options.AudioProcessingFailureReason _audioProcessingFailureReason(String? code) {
+  switch (code) {
+    case 'rejectedInvalidCombination':
+      return track_options.AudioProcessingFailureReason.invalidCombination;
+    case 'rejectedPlatformUnavailable':
+      return track_options.AudioProcessingFailureReason.platformUnavailable;
+    case 'applyFailed':
+      return track_options.AudioProcessingFailureReason.applyFailed;
+    default:
+      return track_options.AudioProcessingFailureReason.unknown;
   }
 }
 

--- a/lib/src/track/local/audio.dart
+++ b/lib/src/track/local/audio.dart
@@ -49,45 +49,24 @@ class LocalAudioTrack extends LocalTrack with AudioTrack, LocalAudioManagementMi
 
   /// Applies runtime audio processing options to this local audio track.
   ///
-  /// Successful results update [currentOptions] and emit
-  /// [LocalTrackOptionsUpdatedEvent]. Operational failures, such as an
-  /// unsupported platform or unavailable device capability, are returned as an
-  /// unsuccessful [track_options.AudioProcessingApplyResult] and leave
+  /// On success, updates [currentOptions] and emits
+  /// [LocalTrackOptionsUpdatedEvent]. When the native layer cannot apply the
+  /// options, throws [track_options.AudioProcessingException] and leaves
   /// [currentOptions] unchanged.
-  ///
-  /// Malformed requests, such as incompatible processing modes, throw
-  /// [track_options.AudioProcessingException]. Unexpected native/channel
-  /// failures may also throw so implementation bugs are not reported as normal
-  /// capability rejections.
-  Future<track_options.AudioProcessingApplyResult> setAudioProcessingOptions(
-      track_options.AudioProcessingOptions options) async {
+  Future<void> setAudioProcessingOptions(track_options.AudioProcessingOptions options) async {
     final nextOptions = currentOptions.copyWith(processing: options);
     final response = await Native.setAudioProcessingOptions(
       mediaStreamTrack.id!,
       options.toMap(),
     );
 
-    final code = track_options.AudioProcessingOptionsResultCode.fromValue(response['code'] as String?);
-    final message = (response['message'] as String?) ?? '';
+    _throwIfAudioProcessingFailed(response);
 
-    // Malformed requests are caller bugs, so surface them loudly rather than
-    // as a silently-unsuccessful result.
-    if (code == track_options.AudioProcessingOptionsResultCode.rejectedInvalidCombination) {
-      throw track_options.AudioProcessingException(
-        code,
-        message.isNotEmpty ? message : 'Unable to apply audio processing options',
-      );
-    }
-
-    final result = track_options.AudioProcessingApplyResult(code, message);
-    if (result.isSuccess) {
-      currentOptions = nextOptions;
-      events.emit(LocalTrackOptionsUpdatedEvent(
-        track: this,
-        options: currentOptions,
-      ));
-    }
-    return result;
+    currentOptions = nextOptions;
+    events.emit(LocalTrackOptionsUpdatedEvent(
+      track: this,
+      options: currentOptions,
+    ));
   }
 
   num? _currentBitrate;
@@ -183,20 +162,73 @@ class LocalAudioTrack extends LocalTrack with AudioTrack, LocalAudioManagementMi
       options,
     );
 
-    if (options.processor != null) {
-      await track.setProcessor(options.processor);
-    }
+    try {
+      if (options.processor != null) {
+        await track.setProcessor(options.processor);
+      }
 
-    // Per-component processing modes are not part of standard capture
-    // constraints; apply them through the native audio processing path.
-    final processing = options.processing;
-    if (processing.echoCancellationMode != track_options.AudioProcessingMode.automatic ||
-        processing.noiseSuppressionMode != track_options.AudioProcessingMode.automatic ||
-        processing.autoGainControlMode != track_options.AudioProcessingMode.automatic ||
-        processing.highPassFilterMode != track_options.AudioProcessingMode.automatic) {
-      await track.setAudioProcessingOptions(processing);
+      // Per-component processing modes are not part of standard capture
+      // constraints; apply them through the native audio processing path.
+      final processing = options.processing;
+      if (processing.echoCancellationMode != track_options.AudioProcessingMode.automatic ||
+          processing.noiseSuppressionMode != track_options.AudioProcessingMode.automatic ||
+          processing.autoGainControlMode != track_options.AudioProcessingMode.automatic ||
+          processing.highPassFilterMode != track_options.AudioProcessingMode.automatic) {
+        await track.setAudioProcessingOptions(processing);
+      }
+    } catch (_) {
+      await track.stop();
+      rethrow;
     }
 
     return track;
   }
+}
+
+void _throwIfAudioProcessingFailed(Map<String, dynamic> response) {
+  final code = response['code'] as String?;
+  final message = (response['message'] as String?) ?? '';
+
+  switch (code) {
+    case 'applied':
+    case 'stored':
+      return;
+    case 'rejectedInvalidCombination':
+      throw track_options.AudioProcessingException(
+        track_options.AudioProcessingFailureReason.invalidCombination,
+        message,
+      );
+    case 'rejectedPlatformUnavailable':
+      throw track_options.AudioProcessingException(
+        track_options.AudioProcessingFailureReason.platformUnavailable,
+        message,
+      );
+    case 'applyFailed':
+      throw track_options.AudioProcessingException(
+        track_options.AudioProcessingFailureReason.applyFailed,
+        message,
+      );
+    case 'unknown':
+    case 'rejectedRemoteTrack':
+      throw track_options.AudioProcessingException(
+        track_options.AudioProcessingFailureReason.unknown,
+        message,
+      );
+    default:
+      throw track_options.AudioProcessingException(
+        track_options.AudioProcessingFailureReason.unknown,
+        _unknownAudioProcessingMessage(code, message),
+      );
+  }
+}
+
+String _unknownAudioProcessingMessage(String? code, String message) {
+  final trimmed = message.trim();
+  if (trimmed.isNotEmpty) {
+    return trimmed;
+  }
+  if (code != null && code.isNotEmpty) {
+    return 'Unknown audio processing result code: $code.';
+  }
+  return '';
 }

--- a/lib/src/track/local/audio.dart
+++ b/lib/src/track/local/audio.dart
@@ -47,6 +47,18 @@ class LocalAudioTrack extends LocalTrack with AudioTrack, LocalAudioManagementMi
     }
   }
 
+  /// Applies runtime audio processing options to this local audio track.
+  ///
+  /// Successful results update [currentOptions] and emit
+  /// [LocalTrackOptionsUpdatedEvent]. Operational failures, such as an
+  /// unsupported platform or unavailable device capability, are returned as an
+  /// unsuccessful [track_options.AudioProcessingApplyResult] and leave
+  /// [currentOptions] unchanged.
+  ///
+  /// Malformed requests, such as incompatible processing modes, throw
+  /// [track_options.AudioProcessingException]. Unexpected native/channel
+  /// failures may also throw so implementation bugs are not reported as normal
+  /// capability rejections.
   Future<track_options.AudioProcessingApplyResult> setAudioProcessingOptions(
       track_options.AudioProcessingOptions options) async {
     final nextOptions = currentOptions.copyWith(processing: options);
@@ -58,8 +70,8 @@ class LocalAudioTrack extends LocalTrack with AudioTrack, LocalAudioManagementMi
     final code = track_options.AudioProcessingOptionsResultCode.fromValue(response['code'] as String?);
     final message = (response['message'] as String?) ?? '';
 
-    // Malformed requests (incompatible modes, or a non-local track) are caller
-    // bugs — surface them loudly rather than as a silently-unsuccessful result.
+    // Malformed requests are caller bugs, so surface them loudly rather than
+    // as a silently-unsuccessful result.
     if (code == track_options.AudioProcessingOptionsResultCode.rejectedInvalidCombination ||
         code == track_options.AudioProcessingOptionsResultCode.rejectedRemoteTrack) {
       throw track_options.AudioProcessingException(

--- a/lib/src/track/local/local.dart
+++ b/lib/src/track/local/local.dart
@@ -96,13 +96,13 @@ mixin AudioTrack on Track {
   }
 
   @override
-  Future<void> onStarted() async {
-    logger.fine('AudioTrack.onStarted()');
+  Future<void> startCapture() async {
+    logger.fine('AudioTrack.startCapture()');
   }
 
   @override
-  Future<void> onStopped() async {
-    logger.fine('AudioTrack.onStopped()');
+  Future<void> stopCapture() async {
+    logger.fine('AudioTrack.stopCapture()');
     for (final group in _captureGroups.values) {
       await group.stop();
     }

--- a/lib/src/track/options.dart
+++ b/lib/src/track/options.dart
@@ -522,9 +522,6 @@ enum AudioProcessingOptionsResultCode {
   /// The options were accepted and stored for the next native audio source.
   stored('stored'),
 
-  /// The request targeted a remote track instead of a local audio track.
-  rejectedRemoteTrack('rejectedRemoteTrack'),
-
   /// The requested mode combination is invalid for the native audio module.
   rejectedInvalidCombination('rejectedInvalidCombination'),
 
@@ -549,7 +546,7 @@ enum AudioProcessingOptionsResultCode {
 }
 
 /// Thrown when the native layer rejects a malformed [AudioProcessingOptions]
-/// request, such as an invalid mode combination or a non-local track.
+/// request, such as an invalid mode combination.
 ///
 /// Capability failures, including unsupported platforms, are returned as an
 /// unsuccessful [AudioProcessingApplyResult] instead of this exception.
@@ -570,7 +567,7 @@ class AudioProcessingException implements Exception {
 /// apply failures. Inspect [isSuccess] before assuming the requested processing
 /// is active.
 ///
-/// A malformed request, such as incompatible modes or a non-local track, throws
+/// A malformed request, such as incompatible modes, throws
 /// [AudioProcessingException] instead.
 class AudioProcessingApplyResult {
   AudioProcessingApplyResult(this.code, this.message);

--- a/lib/src/track/options.dart
+++ b/lib/src/track/options.dart
@@ -534,9 +534,8 @@ enum AudioProcessingOptionsResultCode {
       this == AudioProcessingOptionsResultCode.applied || this == AudioProcessingOptionsResultCode.stored;
 }
 
-/// Thrown when the native layer rejects requested [AudioProcessingOptions]
-/// (e.g. an invalid platform/software combination, or platform processing that
-/// is unavailable on the device).
+/// Thrown when the native layer rejects a malformed [AudioProcessingOptions]
+/// request, such as an invalid mode combination or a non-local track.
 class AudioProcessingException implements Exception {
   AudioProcessingException(this.code, this.message);
 

--- a/lib/src/track/options.dart
+++ b/lib/src/track/options.dart
@@ -510,14 +510,28 @@ class AudioOutputOptions {
 }
 
 /// Result code from applying [AudioProcessingOptions], mirroring the native
-/// `AudioProcessingOptionsResult`. `applied`/`stored` are success; the rest are
-/// rejections.
+/// `AudioProcessingOptionsResult`.
+///
+/// `applied` and `stored` are successful outcomes. Device/platform capability
+/// failures are returned through [AudioProcessingApplyResult]. Malformed caller
+/// requests are surfaced by [AudioProcessingException].
 enum AudioProcessingOptionsResultCode {
+  /// The options were applied to the active native audio processing module.
   applied('applied'),
+
+  /// The options were accepted and stored for the next native audio source.
   stored('stored'),
+
+  /// The request targeted a remote track instead of a local audio track.
   rejectedRemoteTrack('rejectedRemoteTrack'),
+
+  /// The requested mode combination is invalid for the native audio module.
   rejectedInvalidCombination('rejectedInvalidCombination'),
+
+  /// The platform or device cannot provide the requested processing path.
   rejectedPlatformUnavailable('rejectedPlatformUnavailable'),
+
+  /// The native layer attempted to apply the options but failed.
   applyFailed('applyFailed');
 
   const AudioProcessingOptionsResultCode(this.value);
@@ -536,6 +550,9 @@ enum AudioProcessingOptionsResultCode {
 
 /// Thrown when the native layer rejects a malformed [AudioProcessingOptions]
 /// request, such as an invalid mode combination or a non-local track.
+///
+/// Capability failures, including unsupported platforms, are returned as an
+/// unsuccessful [AudioProcessingApplyResult] instead of this exception.
 class AudioProcessingException implements Exception {
   AudioProcessingException(this.code, this.message);
 
@@ -548,10 +565,13 @@ class AudioProcessingException implements Exception {
 
 /// Outcome of applying [AudioProcessingOptions].
 ///
-/// Returned for operational outcomes — `applied`/`stored` (success), and the
-/// device-capability rejections `rejectedPlatformUnavailable`/`applyFailed`
-/// (inspect [isSuccess]). A malformed request (incompatible modes, or a
-/// non-local track) throws [AudioProcessingException] instead.
+/// Returned for operational outcomes: `applied`/`stored` for success, and
+/// `rejectedPlatformUnavailable`/`applyFailed` for normal capability or native
+/// apply failures. Inspect [isSuccess] before assuming the requested processing
+/// is active.
+///
+/// A malformed request, such as incompatible modes or a non-local track, throws
+/// [AudioProcessingException] instead.
 class AudioProcessingApplyResult {
   AudioProcessingApplyResult(this.code, this.message);
 

--- a/lib/src/track/options.dart
+++ b/lib/src/track/options.dart
@@ -509,71 +509,49 @@ class AudioOutputOptions {
   }
 }
 
-/// Result code from applying [AudioProcessingOptions], mirroring the native
-/// `AudioProcessingOptionsResult`.
-///
-/// `applied` and `stored` are successful outcomes. Device/platform capability
-/// failures are returned through [AudioProcessingApplyResult]. Malformed caller
-/// requests are surfaced by [AudioProcessingException].
-enum AudioProcessingOptionsResultCode {
-  /// The options were applied to the active native audio processing module.
-  applied('applied'),
-
-  /// The options were accepted and stored for the next native audio source.
-  stored('stored'),
-
+/// Reason that applying [AudioProcessingOptions] failed.
+enum AudioProcessingFailureReason {
   /// The requested mode combination is invalid for the native audio module.
-  rejectedInvalidCombination('rejectedInvalidCombination'),
+  invalidCombination,
 
   /// The platform or device cannot provide the requested processing path.
-  rejectedPlatformUnavailable('rejectedPlatformUnavailable'),
+  platformUnavailable,
 
   /// The native layer attempted to apply the options but failed.
-  applyFailed('applyFailed');
+  applyFailed,
 
-  const AudioProcessingOptionsResultCode(this.value);
-
-  final String value;
-
-  static AudioProcessingOptionsResultCode fromValue(String? value) =>
-      AudioProcessingOptionsResultCode.values.firstWhere(
-        (e) => e.value == value,
-        orElse: () => AudioProcessingOptionsResultCode.applyFailed,
-      );
-
-  bool get isSuccess =>
-      this == AudioProcessingOptionsResultCode.applied || this == AudioProcessingOptionsResultCode.stored;
+  /// The native layer returned an unrecognized or malformed result.
+  unknown,
 }
 
-/// Thrown when the native layer rejects a malformed [AudioProcessingOptions]
-/// request, such as an invalid mode combination.
-///
-/// Capability failures, including unsupported platforms, are returned as an
-/// unsuccessful [AudioProcessingApplyResult] instead of this exception.
-class AudioProcessingException implements Exception {
-  AudioProcessingException(this.code, this.message);
+String _defaultAudioProcessingMessage(AudioProcessingFailureReason reason) {
+  switch (reason) {
+    case AudioProcessingFailureReason.invalidCombination:
+      return 'The requested audio processing mode combination is invalid.';
+    case AudioProcessingFailureReason.platformUnavailable:
+      return 'Audio processing options are unavailable on this platform or device.';
+    case AudioProcessingFailureReason.applyFailed:
+      return 'The native WebRTC audio processing module could not apply the requested options.';
+    case AudioProcessingFailureReason.unknown:
+      return 'Audio processing options failed for an unknown reason.';
+  }
+}
 
-  final AudioProcessingOptionsResultCode code;
+String _audioProcessingMessageOrDefault(AudioProcessingFailureReason reason, String message) {
+  final trimmed = message.trim();
+  return trimmed.isEmpty ? _defaultAudioProcessingMessage(reason) : trimmed;
+}
+
+/// Thrown when [AudioProcessingOptions] cannot be applied.
+///
+/// [reason] is a stable SDK category. [message] carries native details when
+/// available, or an SDK-provided fallback when native does not include details.
+class AudioProcessingException implements Exception {
+  AudioProcessingException(this.reason, String message) : message = _audioProcessingMessageOrDefault(reason, message);
+
+  final AudioProcessingFailureReason reason;
   final String message;
 
   @override
-  String toString() => 'AudioProcessingException(${code.value}): $message';
-}
-
-/// Outcome of applying [AudioProcessingOptions].
-///
-/// Returned for operational outcomes: `applied`/`stored` for success, and
-/// `rejectedPlatformUnavailable`/`applyFailed` for normal capability or native
-/// apply failures. Inspect [isSuccess] before assuming the requested processing
-/// is active.
-///
-/// A malformed request, such as incompatible modes, throws
-/// [AudioProcessingException] instead.
-class AudioProcessingApplyResult {
-  AudioProcessingApplyResult(this.code, this.message);
-
-  final AudioProcessingOptionsResultCode code;
-  final String message;
-
-  bool get isSuccess => code.isSuccess;
+  String toString() => 'AudioProcessingException(${reason.name}): $message';
 }

--- a/lib/src/track/track.dart
+++ b/lib/src/track/track.dart
@@ -110,11 +110,10 @@ abstract class Track extends DisposableChangeNotifier with EventsEmittable<Track
 
     logger.fine('$objectId.start()');
 
-    startMonitor();
-
     await onStarted();
 
     _active = true;
+    startMonitor();
     return true;
   }
 

--- a/lib/src/track/track.dart
+++ b/lib/src/track/track.dart
@@ -110,7 +110,7 @@ abstract class Track extends DisposableChangeNotifier with EventsEmittable<Track
 
     logger.fine('$objectId.start()');
 
-    await onStarted();
+    await startCapture();
 
     _active = true;
     startMonitor();
@@ -128,7 +128,7 @@ abstract class Track extends DisposableChangeNotifier with EventsEmittable<Track
 
     stopMonitor();
 
-    await onStopped();
+    await stopCapture();
 
     logger.fine('$objectId.stop()');
 
@@ -172,11 +172,14 @@ abstract class Track extends DisposableChangeNotifier with EventsEmittable<Track
   @internal
   Future<bool> monitorStats();
 
+  /// Called by [start] before this track is marked active.
   @internal
-  Future<void> onStarted() async {}
+  Future<void> startCapture() async {}
 
+  /// Called by [stop] while this track is still active, before the media track
+  /// is stopped.
   @internal
-  Future<void> onStopped() async {}
+  Future<void> stopCapture() async {}
 
   @internal
   void startMonitor() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -284,10 +284,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_webrtc
-      sha256: c4e8db6ed337b8c30d76cd7cd8c91693f5495e1aeb556cbcb73f1e5d5bdcf020
+      sha256: "0f89dee7f4c35dab5611f351c3897a3bfe9f7057720cc7da209b52455af4316e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.2"
   frontend_server_client:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
   json_annotation: ^4.9.0
 
   # Fix version to avoid version conflicts between WebRTC-SDK pods, which both this package and flutter_webrtc depend on.
-  flutter_webrtc: 1.5.1
+  flutter_webrtc: 1.5.2
   dart_webrtc: ^1.8.0
 
 dev_dependencies:

--- a/shared_swift/LiveKitPlugin.swift
+++ b/shared_swift/LiveKitPlugin.swift
@@ -429,7 +429,62 @@ public class LiveKitPlugin: NSObject, FlutterPlugin {
             return
         }
 
-        let options = RTCAudioProcessingOptions(
+        let options = LiveKitPlugin.audioProcessingOptions(from: args)
+        let processingResult = audioTrack.setAudioProcessingOptions(options)
+        result([
+            "result": processingResult.isSuccess,
+            "code": LiveKitPlugin.audioProcessingResultCodeString(processingResult.code),
+            "message": processingResult.message,
+        ])
+    }
+
+    public func handleStartLocalRecording(args: [String: Any?], result: @escaping FlutterResult) {
+        guard let adm = FlutterWebRTCPlugin.sharedSingleton()?.peerConnectionFactory?.audioDeviceModule else {
+            result(FlutterError(code: "rejectedPlatformUnavailable", message: "audio device module is unavailable", details: nil))
+            return
+        }
+
+        let options = LiveKitPlugin.audioProcessingOptions(from: args)
+        DispatchQueue.global(qos: .userInitiated).async {
+            let admResult = adm.initAndStartRecording(audioProcessingOptions: options)
+            DispatchQueue.main.async {
+                if admResult == 0 {
+                    result(nil)
+                } else {
+                    result(FlutterError(
+                        code: "applyFailed",
+                        message: "Audio engine returned error code: \(admResult)",
+                        details: nil
+                    ))
+                }
+            }
+        }
+    }
+
+    public func handleStopLocalRecording(result: @escaping FlutterResult) {
+        guard let adm = FlutterWebRTCPlugin.sharedSingleton()?.peerConnectionFactory?.audioDeviceModule else {
+            result(FlutterError(code: "stopLocalRecording", message: "audio device module is unavailable", details: nil))
+            return
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            let admResult = adm.stopRecording()
+            DispatchQueue.main.async {
+                if admResult == 0 {
+                    result(nil)
+                } else {
+                    result(FlutterError(
+                        code: "stopLocalRecording",
+                        message: "Audio engine returned error code: \(admResult)",
+                        details: nil
+                    ))
+                }
+            }
+        }
+    }
+
+    static func audioProcessingOptions(from args: [String: Any?]) -> RTCAudioProcessingOptions {
+        RTCAudioProcessingOptions(
             echoCancellationOptions: RTCAudioProcessingComponentOptions(
                 enabled: (args["echoCancellation"] as? Bool) ?? true,
                 mode: LiveKitPlugin.audioProcessingMode(from: args["echoCancellationMode"] as? String)
@@ -447,13 +502,6 @@ public class LiveKitPlugin: NSObject, FlutterPlugin {
                 mode: LiveKitPlugin.audioProcessingMode(from: args["highPassFilterMode"] as? String)
             )
         )
-
-        let processingResult = audioTrack.setAudioProcessingOptions(options)
-        result([
-            "result": processingResult.isSuccess,
-            "code": LiveKitPlugin.audioProcessingResultCodeString(processingResult.code),
-            "message": processingResult.message,
-        ])
     }
 
     static func audioProcessingMode(from string: String?) -> RTCAudioProcessingMode {
@@ -552,6 +600,10 @@ public class LiveKitPlugin: NSObject, FlutterPlugin {
             handleStartAudioRenderer(args: args, result: result)
         case "stopAudioRenderer":
             handleStopAudioRenderer(args: args, result: result)
+        case "startLocalRecording":
+            handleStartLocalRecording(args: args, result: result)
+        case "stopLocalRecording":
+            handleStopLocalRecording(result: result)
         case "setAudioProcessingOptions":
             handleSetAudioProcessingOptions(args: args, result: result)
         case "getAudioProcessingState":

--- a/shared_swift/LiveKitPlugin.swift
+++ b/shared_swift/LiveKitPlugin.swift
@@ -468,11 +468,11 @@ public class LiveKitPlugin: NSObject, FlutterPlugin {
         switch code {
         case .applied: return "applied"
         case .stored: return "stored"
-        case .rejectedRemoteTrack: return "applyFailed"
+        case .rejectedRemoteTrack: return "unknown"
         case .rejectedInvalidCombination: return "rejectedInvalidCombination"
         case .rejectedPlatformUnavailable: return "rejectedPlatformUnavailable"
         case .applyFailed: return "applyFailed"
-        @unknown default: return "applyFailed"
+        @unknown default: return "unknown"
         }
     }
 

--- a/shared_swift/LiveKitPlugin.swift
+++ b/shared_swift/LiveKitPlugin.swift
@@ -468,7 +468,7 @@ public class LiveKitPlugin: NSObject, FlutterPlugin {
         switch code {
         case .applied: return "applied"
         case .stored: return "stored"
-        case .rejectedRemoteTrack: return "rejectedRemoteTrack"
+        case .rejectedRemoteTrack: return "applyFailed"
         case .rejectedInvalidCombination: return "rejectedInvalidCombination"
         case .rejectedPlatformUnavailable: return "rejectedPlatformUnavailable"
         case .applyFailed: return "applyFailed"

--- a/test/audio/audio_session_test.dart
+++ b/test/audio/audio_session_test.dart
@@ -198,11 +198,49 @@ void main() {
     });
   });
 
-  group('AudioProcessingOptionsResultCode', () {
-    test('maps remote-track native result to apply failure', () {
+  group('AudioProcessingException', () {
+    test('uses fallback messages when native omits details', () {
+      final invalid = track_options.AudioProcessingException(
+        track_options.AudioProcessingFailureReason.invalidCombination,
+        '',
+      );
+      final platformUnavailable = track_options.AudioProcessingException(
+        track_options.AudioProcessingFailureReason.platformUnavailable,
+        '  ',
+      );
+      final applyFailed = track_options.AudioProcessingException(
+        track_options.AudioProcessingFailureReason.applyFailed,
+        '',
+      );
+      final unknown = track_options.AudioProcessingException(
+        track_options.AudioProcessingFailureReason.unknown,
+        '',
+      );
+
+      expect(invalid.message, 'The requested audio processing mode combination is invalid.');
+      expect(platformUnavailable.message, 'Audio processing options are unavailable on this platform or device.');
       expect(
-        track_options.AudioProcessingOptionsResultCode.fromValue('rejectedRemoteTrack'),
-        track_options.AudioProcessingOptionsResultCode.applyFailed,
+        applyFailed.message,
+        'The native WebRTC audio processing module could not apply the requested options.',
+      );
+      expect(unknown.message, 'Audio processing options failed for an unknown reason.');
+    });
+
+    test('preserves native messages when provided', () {
+      final error = track_options.AudioProcessingException(
+        track_options.AudioProcessingFailureReason.applyFailed,
+        '  native detail  ',
+      );
+
+      expect(error.reason, track_options.AudioProcessingFailureReason.applyFailed);
+      expect(error.message, 'native detail');
+      expect(error.toString(), 'AudioProcessingException(applyFailed): native detail');
+    });
+
+    test('exposes unknown failure reason', () {
+      expect(
+        track_options.AudioProcessingFailureReason.values,
+        contains(track_options.AudioProcessingFailureReason.unknown),
       );
     });
   });

--- a/test/audio/audio_session_test.dart
+++ b/test/audio/audio_session_test.dart
@@ -659,6 +659,65 @@ void main() {
         throwsA(isA<PlatformException>().having((error) => error.code, 'code', 'nativeFailure')),
       );
     });
+
+    test('throws platform unavailable when startLocalRecording channel is missing', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        Native.channel,
+        null,
+      );
+
+      await expectLater(
+        Native.startLocalRecording(<String, dynamic>{'echoCancellation': true}),
+        throwsA(isA<PlatformException>().having(
+          (error) => error.code,
+          'code',
+          'rejectedPlatformUnavailable',
+        )),
+      );
+    });
+
+    test('throws platform unavailable when startLocalRecording is unimplemented', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        Native.channel,
+        (call) async {
+          calls.add(call);
+          throw PlatformException(code: 'Unimplemented');
+        },
+      );
+
+      await expectLater(
+        Native.startLocalRecording(<String, dynamic>{'echoCancellation': true}),
+        throwsA(isA<PlatformException>().having(
+          (error) => error.code,
+          'code',
+          'rejectedPlatformUnavailable',
+        )),
+      );
+      expect(calls.single.method, 'startLocalRecording');
+    });
+
+    test('ignores stopLocalRecording platform failures', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        Native.channel,
+        (call) async {
+          calls.add(call);
+          throw PlatformException(code: 'nativeFailure', message: 'boom');
+        },
+      );
+
+      await Native.stopLocalRecording();
+
+      expect(calls.single.method, 'stopLocalRecording');
+    });
+
+    test('ignores stopLocalRecording missing plugin', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        Native.channel,
+        null,
+      );
+
+      await Native.stopLocalRecording();
+    });
   });
 
   group('androidAudioSessionConfigurationToMap', () {

--- a/test/audio/audio_session_test.dart
+++ b/test/audio/audio_session_test.dart
@@ -544,6 +544,73 @@ void main() {
         containsPair('forceSpeakerOutput', true),
       );
     });
+
+    test('returns platform unavailable when audio processing channel is missing', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        Native.channel,
+        null,
+      );
+
+      final result = await Native.setAudioProcessingOptions(
+        'track-id',
+        <String, dynamic>{'echoCancellation': true},
+      );
+
+      expect(
+        result,
+        {
+          'result': false,
+          'code': 'rejectedPlatformUnavailable',
+          'message': 'Audio processing options are unavailable on this platform.',
+        },
+      );
+    });
+
+    test('returns platform unavailable when audio processing method is unimplemented', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        Native.channel,
+        (call) async {
+          calls.add(call);
+          throw PlatformException(
+            code: 'Unimplemented',
+            details: 'livekit for web does not implement ${call.method}',
+          );
+        },
+      );
+
+      final result = await Native.setAudioProcessingOptions(
+        'track-id',
+        <String, dynamic>{'echoCancellation': true},
+      );
+
+      expect(calls.single.method, 'setAudioProcessingOptions');
+      expect(calls.single.arguments, containsPair('trackId', 'track-id'));
+      expect(
+        result,
+        {
+          'result': false,
+          'code': 'rejectedPlatformUnavailable',
+          'message': 'Audio processing options are unavailable on this platform.',
+        },
+      );
+    });
+
+    test('propagates other audio processing channel failures', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        Native.channel,
+        (call) async {
+          throw PlatformException(code: 'nativeFailure', message: 'boom');
+        },
+      );
+
+      await expectLater(
+        Native.setAudioProcessingOptions(
+          'track-id',
+          <String, dynamic>{'echoCancellation': true},
+        ),
+        throwsA(isA<PlatformException>().having((error) => error.code, 'code', 'nativeFailure')),
+      );
+    });
   });
 
   group('androidAudioSessionConfigurationToMap', () {

--- a/test/audio/audio_session_test.dart
+++ b/test/audio/audio_session_test.dart
@@ -22,6 +22,7 @@ import 'package:livekit_client/src/audio/audio_session.dart';
 import 'package:livekit_client/src/audio/audio_session_policy.dart';
 import 'package:livekit_client/src/support/native.dart';
 import 'package:livekit_client/src/support/native_audio.dart' as native_audio;
+import 'package:livekit_client/src/track/options.dart' as track_options;
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -194,6 +195,15 @@ void main() {
       expect(cleared.usageType, isNull);
       expect(cleared.contentType, isNull);
       expect(cleared.forceAudioRouting, isNull);
+    });
+  });
+
+  group('AudioProcessingOptionsResultCode', () {
+    test('maps remote-track native result to apply failure', () {
+      expect(
+        track_options.AudioProcessingOptionsResultCode.fromValue('rejectedRemoteTrack'),
+        track_options.AudioProcessingOptionsResultCode.applyFailed,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- move create-time audio processing setup into the local capture start path so publish/preconnect prepares platform audio processing before WebRTC opens the microphone, matching the Swift SDK flow
- keep `LocalAudioTrack.setAudioProcessingOptions` as a command-style runtime API that returns on success and throws `AudioProcessingException` on failure
- expose structured failure reasons for invalid combinations, unavailable platform support, native apply failures, and unknown failures
- clean up local audio tracks when capture/publish startup fails and keep cleanup failures from masking the original error
- bump `flutter_webrtc` to `1.5.2` for Android audio device module access

## Behavior
- `LocalAudioTrack.create(...)` stores requested audio processing options; it no longer attempts to apply them immediately.
- `track.start()` starts local capture and applies stored processing options before the microphone opens on supported platforms.
- Publish and preconnect paths fail during capture start if the exposed native platform API reports audio processing setup failure.
- Runtime `setAudioProcessingOptions(...)` still applies immediately for active local audio tracks and throws on failed native apply/store.
- Android uses `JavaAudioDeviceModule.prewarmRecording(options)`. That WebRTC API returns `void`, so this PR can surface thrown failures, but clean internal `false` returns from `initRecordingIfNeeded()` / `prewarmRecordingIfNeeded()` are not observable until WebRTC/flutter_webrtc exposes a resultful API.

## Testing
- `flutter pub get`
- `flutter pub get` in `example`
- `flutter analyze --no-pub`
- `flutter test --no-pub`
- `flutter build apk --debug --no-pub` in `example`
- Android emulator smoke test: example joined a room, published local microphone audio, muted/unpublished, and showed no ADM/platform-unavailable errors
