### PR TITLE
fix: improve initial video quality by setting x-google-start-bitrate for all video codecs

### DIFF
--- a/lib/src/core/transport.dart
+++ b/lib/src/core/transport.dart
@@ -29,13 +29,17 @@ import '../utils.dart';
 
 const ddExtensionURI = 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension';
 
-/* The svc codec (av1/vp9) would use a very low bitrate at the begining and
-increase slowly by the bandwidth estimator until it reach the target bitrate. The
-process commonly cost more than 10 seconds cause subscriber will get blur video at
-the first few seconds. So we use a 70% of target bitrate here as the start bitrate to
-eliminate this issue.
-*/
-const startBitrateForSVC = 0.7;
+/*
+ * Video codecs use a very low bitrate at the beginning and increase slowly by
+ * the bandwidth estimator until they reach the target bitrate. The process commonly
+ * costs more than 10 seconds causing subscribers to get blurry video at the first
+ * few seconds. We use x-google-start-bitrate to hint the BWE to start higher.
+ *
+ * Why 90%: Gives ~10% headroom for bandwidth estimation while starting close to target.
+ * Why same for all codecs: Target bitrate already accounts for codec efficiency
+ * (e.g., users set lower targets for VP9/AV1 knowing they're more efficient).
+ */
+const startBitrateMultiplier = 0.9;
 
 class TrackBitrateInfo {
   String? cid;
@@ -204,7 +208,7 @@ class Transport extends Disposable {
           for (var fmtp in media['fmtp']) {
             if (fmtp['payload'] == codecPayload) {
               if (!(fmtp['config'] as String).contains('x-google-start-bitrate')) {
-                fmtp['config'] += ';x-google-start-bitrate=${(trackbr.maxbr * startBitrateForSVC).toInt()}';
+                fmtp['config'] += ';x-google-start-bitrate=${(trackbr.maxbr * startBitrateMultiplier).toInt()}';
               }
               break;
             }

--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -56,7 +56,7 @@ import '../types/other.dart';
 import '../types/participant_permissions.dart';
 import '../types/rpc.dart';
 import '../types/video_dimensions.dart';
-import '../utils.dart' show buildStreamId, mimeTypeToVideoCodecString, Utils, compareVersions, isSVCCodec;
+import '../utils.dart' show buildStreamId, mimeTypeToVideoCodecString, Utils, compareVersions, isSVCCodec, isVideoCodec;
 import 'participant.dart';
 
 /// Represents the current participant in the room. Instance of [LocalParticipant] is automatically
@@ -392,7 +392,8 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
 
       if (kIsWeb && lkBrowser() == BrowserType.firefox && track.kind == TrackType.AUDIO) {
         //TOOD:
-      } else if (isSVCCodec(publishOptions.videoCodec) && encodings?.first.maxBitrate != null) {
+      } else if (isVideoCodec(publishOptions.videoCodec) && encodings?.first.maxBitrate != null) {
+        // Apply start bitrate for all video codecs to prevent initial blurriness
         room.engine.publisher?.setTrackBitrateInfo(TrackBitrateInfo(
             cid: track.getCid(),
             transceiver: track.transceiver,
@@ -490,7 +491,8 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
 
       if (kIsWeb && lkBrowser() == BrowserType.firefox && track.kind == TrackType.AUDIO) {
         //TOOD:
-      } else if (isSVCCodec(publishOptions.videoCodec) && encodings?.first.maxBitrate != null) {
+      } else if (isVideoCodec(publishOptions.videoCodec) && encodings?.first.maxBitrate != null) {
+        // Apply start bitrate for all video codecs to prevent initial blurriness
         room.engine.publisher?.setTrackBitrateInfo(TrackBitrateInfo(
             cid: track.getCid(),
             transceiver: track.transceiver,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -626,6 +626,8 @@ const refreshSubscribedCodecAfterNewCodec = 5000;
 
 bool isSVCCodec(String codec) => ['vp9', 'av1'].contains(codec.toLowerCase());
 
+bool isVideoCodec(String codec) => ['vp8', 'vp9', 'av1', 'h264', 'h265'].contains(codec.toLowerCase());
+
 bool isAV1Codec(String codec) => codec.toLowerCase() == 'av1';
 
 class ScalabilityMode {


### PR DESCRIPTION
## Summary
- Apply `x-google-start-bitrate` SDP hint to all video codecs (VP8, VP9, AV1, H264, H265), not just SVC codecs
- Use 90% of target bitrate as start bitrate to prevent initial blurriness
- Degradation preference already defaults to `maintainResolution`


## Problem
Video starts blurry for 5-15 seconds before improving. This is caused by WebRTC's bandwidth estimator starting at ~300kbps and slowly ramping up to the target bitrate.

## Solution
**x-google-start-bitrate**: Tell WebRTC to start at 90% of target bitrate instead of ramping up from ~300kbps. Applied consistently to all video codecs.

 Note, The PR only addresses the x-google-start-bitrate fix (changing from SVC-only to all video codecs, and using 0.9 multiplier)
  - The maintainResolution default was already in place in Flutter SDK, so no change was needed for that part
  

## Test plan
- [ ] Verify video quality is sharp from the start when publishing
- [ ] Test with VP8, VP9, H264, AV1 codecs
- [ ] Verify bandwidth estimator adapts properly if network can't handle the start bitrate

🤖 Generated with [Claude Code](https://claude.com/claude-code)