### PR TITLE
fix: allow selectAudioOutput on Android

### DIFF
--- a/.changes/fix-android-select-audio-output
+++ b/.changes/fix-android-select-audio-output
@@ -1,0 +1,1 @@
+patch type="fixed" "Allow selectAudioOutput on Android"

--- a/lib/src/hardware/hardware.dart
+++ b/lib/src/hardware/hardware.dart
@@ -119,8 +119,8 @@ class Hardware {
   }
 
   Future<void> selectAudioOutput(MediaDevice device) async {
-    if (!lkPlatformIsDesktop()) {
-      logger.warning('selectAudioOutput is only supported on Desktop');
+    if (lkPlatformIs(PlatformType.web) || lkPlatformIs(PlatformType.iOS)) {
+      logger.warning('selectAudioOutput is not supported on Web or iOS');
       return;
     }
     selectedAudioOutput = device;


### PR DESCRIPTION
`Helper.selectAudioOutput` already routes audio on Android via device ID strings (speaker, earpiece, bluetooth, wired-headset). The desktop-only gate was silently swallowing the call and leaving `room.setAudioOutputDevice()` as a no-op on Android.