### PR TITLE
Fix video render mode switching

### DIFF
--- a/.changes/video-render-mode-switch
+++ b/.changes/video-render-mode-switch
@@ -1,0 +1,1 @@
+patch type="fixed" "Handle switching video render modes without stale renderers"

--- a/lib/src/widgets/video_track_renderer.dart
+++ b/lib/src/widgets/video_track_renderer.dart
@@ -107,9 +107,10 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
   // Used to compute visibility information
   late VideoTrackViewRegistration _viewRegistration;
 
-  bool get _shouldUsePlatformView =>
-      widget.renderMode == VideoRenderMode.platformView &&
-      [PlatformType.iOS, PlatformType.macOS].contains(lkPlatform());
+  bool _usesPlatformView(VideoRenderMode renderMode) =>
+      renderMode == VideoRenderMode.platformView && [PlatformType.iOS, PlatformType.macOS].contains(lkPlatform());
+
+  bool get _shouldUsePlatformView => _usesPlatformView(widget.renderMode);
 
   double? get _rendererAspectRatio {
     final renderer = _renderer;
@@ -123,9 +124,19 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
     if (_shouldUsePlatformView) {
       return null;
     }
+    // A leftover platform view controller is owned by its RTCVideoPlatFormView
+    // widget, which disposes it on unmount. Only drop our reference here.
+    if (_renderer != null && _renderer is! rtc.RTCVideoRenderer) {
+      _detachRenderer();
+    }
     if (_renderer == null) {
-      _renderer = rtc.RTCVideoRenderer();
-      await _renderer!.initialize();
+      final cachedRenderer = widget.cachedRenderer;
+      if (cachedRenderer != null) {
+        _renderer = cachedRenderer;
+      } else {
+        _renderer = rtc.RTCVideoRenderer();
+        await _renderer!.initialize();
+      }
     }
     await _attach();
     return _renderer!;
@@ -152,20 +163,43 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
   }
 
   void disposeRenderer() {
+    final renderer = _renderer;
+    _renderer = null;
     try {
-      _renderer?.onResize = null;
-      _renderer?.srcObject = null;
-      unawaited(_renderer?.dispose());
-      _renderer = null;
+      renderer?.onResize = null;
+      renderer?.srcObject = null;
+      unawaited(renderer?.dispose());
     } catch (e) {
       logger.warning('Got error disposing renderer: $e');
+    }
+  }
+
+  void _detachRenderer() {
+    final renderer = _renderer;
+    _renderer = null;
+    try {
+      renderer?.onResize = null;
+      renderer?.srcObject = null;
+    } catch (e) {
+      logger.warning('Got error detaching renderer: $e');
+    }
+  }
+
+  void _resetRenderer({required bool dispose}) {
+    unawaited(_listener?.dispose());
+    _listener = null;
+    _aspectRatio = null;
+    if (dispose) {
+      disposeRenderer();
+    } else {
+      _detachRenderer();
     }
   }
 
   @override
   void initState() {
     super.initState();
-    if (widget.cachedRenderer != null) {
+    if (!_shouldUsePlatformView && widget.cachedRenderer != null) {
       _renderer = widget.cachedRenderer;
     }
     _viewRegistration = widget.track.addViewRegistration(pixelDensity: widget.adaptiveStreamPixelDensity);
@@ -213,6 +247,16 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
   @override
   void didUpdateWidget(covariant VideoTrackRenderer oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (_usesPlatformView(oldWidget.renderMode) != _shouldUsePlatformView) {
+      final renderer = _renderer;
+      // Only dispose texture renderers we created ourselves. Platform view
+      // controllers are owned and disposed by RTCVideoPlatFormView, and a
+      // caller-provided cachedRenderer is owned by the caller. Disposing the
+      // cachedRenderer here would break re-adopting it on a later switch back.
+      final ownsRenderer = renderer is rtc.RTCVideoRenderer && !identical(renderer, widget.cachedRenderer);
+      _resetRenderer(dispose: ownsRenderer && oldWidget.autoDisposeRenderer);
+    }
+
     if (widget.track != oldWidget.track) {
       oldWidget.track.removeViewRegistration(_viewRegistration);
       _viewRegistration = widget.track.addViewRegistration(pixelDensity: widget.adaptiveStreamPixelDensity);

--- a/lib/src/widgets/video_track_renderer.dart
+++ b/lib/src/widgets/video_track_renderer.dart
@@ -233,7 +233,7 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
       // Only dispose texture renderers we created ourselves. Platform view
       // controllers belong to RTCVideoPlatFormView and a cachedRenderer
       // belongs to the caller, who may hand it back on a later switch.
-      final ownsRenderer = _renderer is rtc.RTCVideoRenderer && !identical(_renderer, widget.cachedRenderer);
+      final ownsRenderer = _renderer is rtc.RTCVideoRenderer && !identical(_renderer, oldWidget.cachedRenderer);
       unawaited(_listener?.dispose());
       _listener = null;
       _aspectRatio = null;

--- a/lib/src/widgets/video_track_renderer.dart
+++ b/lib/src/widgets/video_track_renderer.dart
@@ -127,7 +127,7 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
     // A leftover platform view controller is owned by its RTCVideoPlatFormView
     // widget, which disposes it on unmount. Only drop our reference here.
     if (_renderer != null && _renderer is! rtc.RTCVideoRenderer) {
-      _detachRenderer();
+      _releaseRenderer(dispose: false);
     }
     if (_renderer == null) {
       final cachedRenderer = widget.cachedRenderer;
@@ -162,37 +162,19 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
     unawaited(rtc.Helper.setExposurePoint(videoTrack, point));
   }
 
-  void disposeRenderer() {
+  /// Detaches the current renderer and drops our reference to it.
+  /// Pass [dispose] only for renderers this widget created and owns.
+  void _releaseRenderer({required bool dispose}) {
     final renderer = _renderer;
     _renderer = null;
     try {
       renderer?.onResize = null;
       renderer?.srcObject = null;
-      unawaited(renderer?.dispose());
+      if (dispose) {
+        unawaited(renderer?.dispose());
+      }
     } catch (e) {
-      logger.warning('Got error disposing renderer: $e');
-    }
-  }
-
-  void _detachRenderer() {
-    final renderer = _renderer;
-    _renderer = null;
-    try {
-      renderer?.onResize = null;
-      renderer?.srcObject = null;
-    } catch (e) {
-      logger.warning('Got error detaching renderer: $e');
-    }
-  }
-
-  void _resetRenderer({required bool dispose}) {
-    unawaited(_listener?.dispose());
-    _listener = null;
-    _aspectRatio = null;
-    if (dispose) {
-      disposeRenderer();
-    } else {
-      _detachRenderer();
+      logger.warning('Got error releasing renderer: $e');
     }
   }
 
@@ -217,7 +199,7 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
     widget.track.removeViewRegistration(_viewRegistration);
     unawaited(_listener?.dispose());
     if (widget.autoDisposeRenderer) {
-      disposeRenderer();
+      _releaseRenderer(dispose: true);
     }
     super.dispose();
   }
@@ -248,13 +230,14 @@ class _VideoTrackRendererState extends State<VideoTrackRenderer> {
   void didUpdateWidget(covariant VideoTrackRenderer oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (_usesPlatformView(oldWidget.renderMode) != _shouldUsePlatformView) {
-      final renderer = _renderer;
       // Only dispose texture renderers we created ourselves. Platform view
-      // controllers are owned and disposed by RTCVideoPlatFormView, and a
-      // caller-provided cachedRenderer is owned by the caller. Disposing the
-      // cachedRenderer here would break re-adopting it on a later switch back.
-      final ownsRenderer = renderer is rtc.RTCVideoRenderer && !identical(renderer, widget.cachedRenderer);
-      _resetRenderer(dispose: ownsRenderer && oldWidget.autoDisposeRenderer);
+      // controllers belong to RTCVideoPlatFormView and a cachedRenderer
+      // belongs to the caller, who may hand it back on a later switch.
+      final ownsRenderer = _renderer is rtc.RTCVideoRenderer && !identical(_renderer, widget.cachedRenderer);
+      unawaited(_listener?.dispose());
+      _listener = null;
+      _aspectRatio = null;
+      _releaseRenderer(dispose: ownsRenderer && oldWidget.autoDisposeRenderer);
     }
 
     if (widget.track != oldWidget.track) {


### PR DESCRIPTION
## Summary

Switching `renderMode` on a live `VideoTrackRenderer` (texture to platformView or back) previously misbehaved on iOS, and would have on macOS after #1116:

- platformView to texture crashed during build. `_renderer` still held the `RTCVideoPlatformViewController`, which then failed the `as rtc.RTCVideoRenderer` cast.
- texture to platformView leaked the old texture renderer. It stayed attached to `srcObject`, kept consuming decoded frames and held its GPU texture.
- initState adopted a texture-type `cachedRenderer` even in platform view mode.

## Fix

`didUpdateWidget` now resets the renderer when the effective render mode changes, with ownership respected:

- Platform view controllers are only detached, never disposed here. They are created and disposed by `RTCVideoPlatFormView`, so disposing them from this widget raced its own dispose (the controller's `_disposed` guard is set only after two awaits, so both dispose calls could pass it).
- A caller-provided `cachedRenderer` is never disposed on a mode switch, so it can be re-adopted when switching back.
- Self-created texture renderers are disposed according to `autoDisposeRenderer`, matching unmount behavior.

## Testing

- `flutter analyze` and `dart format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)