### PR TITLE
chore(audio): mark pre-released audio APIs as experimental

### DIFF
--- a/lib/src/audio/audio_manager.dart
+++ b/lib/src/audio/audio_manager.dart
@@ -34,6 +34,9 @@ export 'microphone_mute_mode.dart';
 /// Surfaced by [AudioManager] from real audio-engine lifecycle events on the
 /// native side (iOS and macOS). This is the source of truth for audio activity,
 /// replacing the legacy track-counting state.
+///
+/// Experimental: this API may change in a future release.
+@experimental
 class AudioEngineState {
   /// Whether the engine has playout (output / remote audio) enabled.
   final bool isPlayoutEnabled;
@@ -95,10 +98,16 @@ class AudioManager {
 
   /// The current audio engine state, derived from native engine lifecycle
   /// events (iOS/macOS). On platforms without engine events this stays idle.
+  ///
+  /// Experimental: this API may change in a future release.
+  @experimental
   AudioEngineState get audioEngineState =>
       AudioEngineState(isPlayoutEnabled: _isPlayoutEnabled, isRecordingEnabled: _isRecordingEnabled);
 
   /// A broadcast stream of audio engine state changes (native engine lifecycle).
+  ///
+  /// Experimental: this API may change in a future release.
+  @experimental
   Stream<AudioEngineState> get audioEngineStateStream => _audioEngineStateController.stream;
 
   // externalCallSystem keeps engine-driven configuration (like automatic) but
@@ -177,6 +186,9 @@ class AudioManager {
   ///
   /// Under [AudioSessionManagementMode.externalCallSystem] the mode is
   /// preserved: the configuration is applied without activating the session.
+  ///
+  /// Experimental: this API may change in a future release.
+  @experimental
   Future<void> setAudioSessionOptions(AudioSessionOptions options) async {
     await _enterManualMode();
     _options = options;
@@ -224,6 +236,9 @@ class AudioManager {
   /// Prefer setting this before connecting to a room. flutter_webrtc's own
   /// native audio management is always disabled (LiveKit owns the session).
   /// Switching back to automatic mode reapplies LiveKit's managed policy.
+  ///
+  /// Experimental: this API may change in a future release.
+  @experimental
   Future<void> setAudioSessionManagementMode(AudioSessionManagementMode mode) async {
     final previousMode = _managementMode;
     _managementMode = mode;
@@ -250,6 +265,9 @@ class AudioManager {
   /// [AudioSessionManagementMode.manual] so LiveKit does not re-activate the
   /// session on its own. Re-apply a configuration with [setAudioSessionOptions],
   /// or hand control back with [setAudioSessionManagementMode].
+  ///
+  /// Experimental: this API may change in a future release.
+  @experimental
   Future<void> deactivateAudioSession() async {
     if (_managementMode == AudioSessionManagementMode.externalCallSystem) {
       logger.warning('deactivateAudioSession skipped: the external call system owns session activation');

--- a/lib/src/audio/audio_manager.dart
+++ b/lib/src/audio/audio_manager.dart
@@ -430,6 +430,9 @@ class AudioManager {
   /// the engine rather than any single track. Use it to verify native state
   /// after a `LocalAudioTrack.setAudioProcessingOptions` request. Returns
   /// `null` when the native side cannot provide it.
+  ///
+  /// Experimental: this API may change in a future release.
+  @experimental
   Future<AudioProcessingState?> getAudioProcessingState() async {
     final response = await Native.getAudioProcessingState();
     if (response == null) return null;

--- a/lib/src/audio/audio_processing_state.dart
+++ b/lib/src/audio/audio_processing_state.dart
@@ -12,9 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:meta/meta.dart';
+
 import '../track/options.dart';
 
 /// The implementation in effect for an audio processing component.
+///
+/// Experimental: this API may change in a future release.
+@experimental
 enum AudioProcessingImplementation {
   unknown('unknown'),
   disabled('disabled'),
@@ -41,6 +46,9 @@ AudioProcessingMode _modeFromValue(String? value) {
 
 /// The caller's request for one audio processing component: enabled flag plus
 /// implementation mode.
+///
+/// Experimental: this API may change in a future release.
+@experimental
 class AudioProcessingComponentRequest {
   const AudioProcessingComponentRequest({
     required this.enabled,
@@ -61,6 +69,9 @@ class AudioProcessingComponentRequest {
 /// three stages of one pipeline: requested (caller intent) -> resolved (the
 /// engine's per-path decision) -> active (live truth), with [effective] as
 /// the merged verdict.
+///
+/// Experimental: this API may change in a future release.
+@experimental
 class AudioProcessingComponentState {
   const AudioProcessingComponentState({
     this.requested,
@@ -117,6 +128,9 @@ class AudioProcessingComponentState {
 /// engine-wide, so this reflects what is actually applied (per-component
 /// [AudioProcessingComponentState.effective]) versus what was requested — for
 /// the whole engine, not a single track.
+///
+/// Experimental: this API may change in a future release.
+@experimental
 class AudioProcessingState {
   const AudioProcessingState({
     required this.hasAudioProcessingModule,

--- a/lib/src/audio/audio_session.dart
+++ b/lib/src/audio/audio_session.dart
@@ -18,6 +18,8 @@ import 'package:meta/meta.dart';
 
 import '../support/value_or_absent.dart';
 
+/// Experimental: this API may change in a future release.
+@experimental
 enum AudioSessionManagementMode {
   /// LiveKit updates the platform audio session based on room/track lifecycle.
   automatic,
@@ -55,6 +57,9 @@ enum AudioSessionManagementMode {
 }
 
 @immutable
+
+/// Experimental: this API may change in a future release.
+@experimental
 class AudioSessionOptions {
   /// Exact Apple session configuration for manual mode.
   final AppleAudioSessionConfiguration apple;
@@ -102,6 +107,8 @@ class AudioSessionOptions {
 }
 
 // https://developer.apple.com/documentation/avfaudio/avaudiosession/category
+/// Experimental: this API may change in a future release.
+@experimental
 enum AppleAudioCategory {
   soloAmbient,
   playback,
@@ -111,6 +118,8 @@ enum AppleAudioCategory {
 }
 
 // https://developer.apple.com/documentation/avfaudio/avaudiosession/categoryoptions
+/// Experimental: this API may change in a future release.
+@experimental
 enum AppleAudioCategoryOption {
   mixWithOthers, // Only playAndRecord, playback, or multiRoute.
   duckOthers, // Only playAndRecord, playback, or multiRoute.
@@ -122,6 +131,8 @@ enum AppleAudioCategoryOption {
 }
 
 // https://developer.apple.com/documentation/avfaudio/avaudiosession/mode
+/// Experimental: this API may change in a future release.
+@experimental
 enum AppleAudioMode {
   default_,
   gameChat,
@@ -135,6 +146,9 @@ enum AppleAudioMode {
 }
 
 @immutable
+
+/// Experimental: this API may change in a future release.
+@experimental
 class AppleAudioSessionConfiguration {
   /// AVAudioSession category.
   final AppleAudioCategory? category;
@@ -179,6 +193,8 @@ class AppleAudioSessionConfiguration {
       );
 }
 
+/// Experimental: this API may change in a future release.
+@experimental
 enum AndroidAudioMode {
   normal,
   callScreening,
@@ -187,6 +203,8 @@ enum AndroidAudioMode {
   ringtone,
 }
 
+/// Experimental: this API may change in a future release.
+@experimental
 enum AndroidAudioFocusMode {
   gain,
   gainTransient,
@@ -194,6 +212,8 @@ enum AndroidAudioFocusMode {
   gainTransientMayDuck,
 }
 
+/// Experimental: this API may change in a future release.
+@experimental
 enum AndroidAudioStreamType {
   accessibility,
   alarm,
@@ -205,6 +225,8 @@ enum AndroidAudioStreamType {
   voiceCall,
 }
 
+/// Experimental: this API may change in a future release.
+@experimental
 enum AndroidAudioAttributesUsageType {
   alarm,
   assistanceAccessibility,
@@ -221,6 +243,8 @@ enum AndroidAudioAttributesUsageType {
   voiceCommunicationSignalling,
 }
 
+/// Experimental: this API may change in a future release.
+@experimental
 enum AndroidAudioAttributesContentType {
   movie,
   music,
@@ -230,6 +254,9 @@ enum AndroidAudioAttributesContentType {
 }
 
 @immutable
+
+/// Experimental: this API may change in a future release.
+@experimental
 class AndroidAudioSessionConfiguration {
   /// Android AudioManager mode.
   final AndroidAudioMode? audioMode;

--- a/lib/src/support/value_or_absent.dart
+++ b/lib/src/support/value_or_absent.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import 'package:meta/meta.dart';
+
 /// Distinguishes an omitted copy value from an explicit replacement value.
 ///
 /// This is useful for `copyWith` methods where a nullable field must be able to
@@ -33,6 +35,9 @@
 /// example.copyWith(name: ValueOrAbsent.value('room')); // set name
 /// example.copyWith(name: ValueOrAbsent.value(null)); // clear name
 /// ```
+///
+/// Experimental: this API may change in a future release.
+@experimental
 sealed class ValueOrAbsent<T> {
   const ValueOrAbsent();
 

--- a/lib/src/track/local/audio.dart
+++ b/lib/src/track/local/audio.dart
@@ -56,6 +56,9 @@ class LocalAudioTrack extends LocalTrack with AudioTrack, LocalAudioManagementMi
   /// [LocalTrackOptionsUpdatedEvent]. When the native layer cannot apply the
   /// options, throws [track_options.AudioProcessingException] and leaves
   /// [currentOptions] unchanged.
+  ///
+  /// Experimental: this API may change in a future release.
+  @experimental
   Future<void> setAudioProcessingOptions(track_options.AudioProcessingOptions options) async {
     final nextOptions = currentOptions.copyWith(processing: options);
     final response = await Native.setAudioProcessingOptions(

--- a/lib/src/track/options.dart
+++ b/lib/src/track/options.dart
@@ -14,6 +14,8 @@
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 
+import 'package:meta/meta.dart';
+
 import '../support/native.dart';
 import '../support/platform.dart';
 import '../track/local/audio.dart';
@@ -243,6 +245,9 @@ abstract class VideoCaptureOptions extends LocalTrackOptions {
 }
 
 /// Selects whether a voice-processing component uses platform or software processing.
+///
+/// Experimental: this API may change in a future release.
+@experimental
 enum AudioProcessingMode {
   automatic('auto'),
   platform('platform'),
@@ -260,6 +265,9 @@ enum AudioProcessingMode {
 /// the updated processing config. The effective audio processing module config
 /// is shared by the native voice engine/channel, so conflicting updates from
 /// multiple local tracks are not isolated per track.
+///
+/// Experimental: this API may change in a future release.
+@experimental
 class AudioProcessingOptions {
   const AudioProcessingOptions({
     required this.echoCancellation,
@@ -510,6 +518,9 @@ class AudioOutputOptions {
 }
 
 /// Reason that applying [AudioProcessingOptions] failed.
+///
+/// Experimental: this API may change in a future release.
+@experimental
 enum AudioProcessingFailureReason {
   /// The requested mode combination is invalid for the native audio module.
   invalidCombination,
@@ -546,6 +557,9 @@ String _audioProcessingMessageOrDefault(AudioProcessingFailureReason reason, Str
 ///
 /// [reason] is a stable SDK category. [message] carries native details when
 /// available, or an SDK-provided fallback when native does not include details.
+///
+/// Experimental: this API may change in a future release.
+@experimental
 class AudioProcessingException implements Exception {
   AudioProcessingException(this.reason, String message) : message = _audioProcessingMessageOrDefault(reason, message);
 


### PR DESCRIPTION
## Summary

Marks the audio APIs that are new since 2.8.0 as `@experimental` before they ship in a stable release, so their shape can still evolve without a breaking-change dance.

**Marked experimental**

- Audio session surface: `AudioSessionOptions`, `AppleAudioSessionConfiguration`, `AndroidAudioSessionConfiguration`, the platform enums, `AudioSessionManagementMode`, and `ValueOrAbsent`
- `AudioManager` session methods: `setAudioSessionOptions`, `setAudioSessionManagementMode`, `deactivateAudioSession`
- Engine state observability: `AudioEngineState`, `audioEngineState`, `audioEngineStateStream`
- Audio processing surface: `AudioProcessingOptions`, `AudioProcessingMode`, `AudioProcessingFailureReason`, `AudioProcessingException`, `LocalAudioTrack.setAudioProcessingOptions`, and the `AudioProcessingState` diagnostic types

**Deliberately left stable**

- `MicrophoneMuteMode` APIs, which mirror the Swift SDK enum that has been stable since 2.10.0
- Speaker output preference methods, which the deprecated `Hardware` APIs reference as migration targets
- `AudioCaptureOptions`, which predates 2.9.0. Only the new `AudioProcessingOptions` interface it implements is marked
- Engine availability and `externalCallSystem` were already marked in #1127

Annotations only, no behavior change. No changeset since this does not alter released behavior, but happy to add one if we want it called out in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)