### PR TITLE
Remove non-public buttonPressed: selector from broadcast picker activation

### DIFF
--- a/.changes/broadcast-picker-private-selector
+++ b/.changes/broadcast-picker-private-selector
@@ -1,0 +1,1 @@
+patch type="fixed" "Remove non-public buttonPressed: selector from broadcast picker activation"

--- a/ios/Classes/BroadcastManager.swift
+++ b/ios/Classes/BroadcastManager.swift
@@ -16,6 +16,7 @@
 
 import Combine
 import ReplayKit
+import UIKit
 
 @available(iOS 13.0, *)
 final class BroadcastManager {
@@ -44,8 +45,10 @@ final class BroadcastManager {
         view.preferredExtension = preferredExtension
         view.showsMicrophoneButton = false
 
-        let selector = NSSelectorFromString("buttonPressed:")
-        guard view.responds(to: selector) else { return }
-        view.perform(selector, with: nil)
+        guard let button = view.subviews.compactMap({ $0 as? UIButton }).first else {
+            print("[LiveKit] Unable to find button in RPSystemBroadcastPickerView")
+            return
+        }
+        button.sendActions(for: .touchUpInside)
     }
 }


### PR DESCRIPTION
## Summary

Apple's automated App Review flags the literal `buttonPressed:` selector string in application binaries (ITMS-90338 / Guideline 2.5.1) and blocks App Store submissions. Since the plugin compiles `ios/Classes/**` into every app, any iOS app using `livekit_client` is exposed — even if it never uses screen sharing or ReplayKit.

`BroadcastManager.showPicker(for:)` constructed and performed the private selector to programmatically activate the system broadcast picker (reached via `setScreenShare` → `broadcastRequestActivation` method channel). It now activates the picker using only public API: locate the picker's `UIButton` subview and fire it via `sendActions(for: .touchUpInside)`. If the button is ever not found (e.g. a future OS changes the view hierarchy), a warning is logged instead of silently no-opping.

No API changes; runtime behavior is identical.

## Verification

- `rg buttonPressed ios/ macos/` returns no matches, so the selector string no longer reaches downstream binaries
- `swiftc -typecheck` against the iOS simulator SDK passes for the changed file and its dependencies