### PR TITLE
fix: don't set zero size if size is unknown

### DIFF
--- a/.changes/fix-data-stream-size
+++ b/.changes/fix-data-stream-size
@@ -1,0 +1,1 @@
+patch type="fixed" "Omit data stream totalLength when size is unknown"

--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -1150,7 +1150,7 @@ extension DataStreamParticipantMethods on LocalParticipant {
     );
 
     final header = lk_models.DataStream_Header(
-      totalLength: Int64(info.size),
+      totalLength: options?.totalSize != null ? Int64(options!.totalSize!) : null,
       mimeType: info.mimeType,
       streamId: streamId,
       topic: options?.topic,

--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -1062,7 +1062,7 @@ extension DataStreamParticipantMethods on LocalParticipant {
       mimeType: info.mimeType,
       topic: info.topic,
       timestamp: Int64(timestamp),
-      totalLength: Int64(options?.totalSize ?? 0),
+      totalLength: options?.totalSize != null ? Int64(options!.totalSize!) : null,
       attributes: options?.attributes.entries,
       textHeader: lk_models.DataStream_TextHeader(
         version: options?.version,


### PR DESCRIPTION
Sending zero instead of null confuses other sdks (at least rust), e.g. [here](https://github.com/livekit/rust-sdks/blob/e37adc1dc4cb90322733fcb0fe1155262f309ff1/livekit-data-stream/src/incoming.rs#L325)