### PR TITLE
feat: Swift Package Manager support for iOS and macOS

### DIFF
--- a/.changes/swift-package-manager
+++ b/.changes/swift-package-manager
@@ -1,0 +1,1 @@
+minor type="added" "Swift Package Manager support for iOS and macOS. CocoaPods remains fully supported."

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -115,6 +115,7 @@ jobs:
         working-directory: ./example
         run: |
           mkdir -p "$RUNNER_TEMP/example-build"
+          rm -rf build
           ln -s "$RUNNER_TEMP/example-build" build
       - name: Build for iOS
         working-directory: ./example
@@ -145,6 +146,7 @@ jobs:
         working-directory: ./example
         run: |
           mkdir -p "$RUNNER_TEMP/example-build"
+          rm -rf build
           ln -s "$RUNNER_TEMP/example-build" build
       - name: Build for macOS
         working-directory: ./example

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -107,6 +107,15 @@ jobs:
           else
             xcodebuild -downloadPlatform iOS
           fi
+      # The Flutter tool copies plugins with SwiftPM plugin dependencies into the
+      # app build directory with rsync. Since the example lives inside the plugin
+      # repo that copy would recurse into its own output, so point the build
+      # directory outside the repository.
+      - name: Move example build dir outside the repository
+        working-directory: ./example
+        run: |
+          mkdir -p "$RUNNER_TEMP/example-build"
+          ln -s "$RUNNER_TEMP/example-build" build
       - name: Build for iOS
         working-directory: ./example
         run: flutter build ios --release --no-codesign
@@ -131,6 +140,12 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v6
       - uses: ./.github/actions/setup-flutter
+      # See the iOS job, same flutter tool rsync recursion workaround.
+      - name: Move example build dir outside the repository
+        working-directory: ./example
+        run: |
+          mkdir -p "$RUNNER_TEMP/example-build"
+          ln -s "$RUNNER_TEMP/example-build" build
       - name: Build for macOS
         working-directory: ./example
         run: flutter build macos --release

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		896215755592B078E91F47B7 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09B43753FB1E220F505A0AA8 /* Pods_Runner.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -65,6 +66,7 @@
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -92,6 +94,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				896215755592B078E91F47B7 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -119,6 +122,7 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
@@ -203,7 +207,6 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				D7FECD302860997500D04D1C /* Embed App Extensions */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				D9316257C44ACC699FF042FD /* [CP] Embed Pods Frameworks */,
 				846FAB5D745587A695E025C5 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
@@ -212,6 +215,9 @@
 				D7FECD2E2860997500D04D1C /* PBXTargetDependency */,
 			);
 			name = Runner;
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			productName = Runner;
 			productReference = 97C146EE1CF9000F007C117D /* Runner.app */;
 			productType = "com.apple.product-type.application";
@@ -262,6 +268,9 @@
 				Base,
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -341,23 +350,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
-		};
-		D9316257C44ACC699FF042FD /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 		F30F68AB50F7F85C7927F195 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -826,6 +818,20 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 97C146E61CF9000F007C117D /* Project object */;
 }

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				D7FECD302860997500D04D1C /* Embed App Extensions */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				D9316257C44ACC699FF042FD /* [CP] Embed Pods Frameworks */,
 				846FAB5D745587A695E025C5 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
@@ -350,6 +351,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
+		};
+		D9316257C44ACC699FF042FD /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		F30F68AB50F7F85C7927F195 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "/bin/sh &quot;$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh&quot; prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "97C146ED1CF9000F007C117D"
+                     BuildableName = "Runner.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
 		68BB07F6271CCD00006A51C2 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B68429BE2B91C13835FDA3EA /* Pods_Runner.framework */; };
 		68BB07F7271CCD00006A51C2 /* Pods_Runner.framework in Bundle Framework */ = {isa = PBXBuildFile; fileRef = B68429BE2B91C13835FDA3EA /* Pods_Runner.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -70,6 +71,7 @@
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
 		3E50A2648E87CCDA0D2CD408 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		79954C9DA9D4E0174C7AAEBA /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
@@ -82,6 +84,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				68BB07F6271CCD00006A51C2 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -133,6 +136,7 @@
 		33CEB47122A05771004F2AC0 /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */,
 				33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */,
 				33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */,
@@ -185,7 +189,6 @@
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
-				514FABDBA3BE0B4C6B1D1F14 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -193,6 +196,9 @@
 				33CC11202044C79F0003C045 /* PBXTargetDependency */,
 			);
 			name = Runner;
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			productName = Runner;
 			productReference = 33CC10ED2044A3C60003C045 /* example.app */;
 			productType = "com.apple.product-type.application";
@@ -232,6 +238,9 @@
 				Base,
 			);
 			mainGroup = 33CC10E42044A3C60003C045;
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+			);
 			productRefGroup = 33CC10EE2044A3C60003C045 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -292,23 +301,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
-		};
-		514FABDBA3BE0B4C6B1D1F14 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 		5D599FB63CA86BC58775E96F /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -636,6 +628,20 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 33CC10E52044A3C60003C045 /* Project object */;
 }

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				514FABDBA3BE0B4C6B1D1F14 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -301,6 +302,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
+		};
+		514FABDBA3BE0B4C6B1D1F14 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		5D599FB63CA86BC58775E96F /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "&quot;$FLUTTER_ROOT&quot;/packages/flutter_tools/bin/macos_assemble.sh prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "33CC10EC2044A3C60003C045"
+                     BuildableName = "example.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/ios/livekit_client/Package.swift
+++ b/ios/livekit_client/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "livekit_client",
+    platforms: [
+        .iOS("13.0")
+    ],
+    products: [
+        .library(name: "livekit-client", targets: ["livekit_client"])
+    ],
+    dependencies: [
+        .package(name: "FlutterFramework", path: "../FlutterFramework"),
+        // Resolved by the Flutter tool to the flutter_webrtc plugin package.
+        .package(name: "flutter_webrtc", path: "../flutter_webrtc")
+    ],
+    targets: [
+        .target(
+            name: "livekit_client",
+            dependencies: [
+                .product(name: "FlutterFramework", package: "FlutterFramework"),
+                .product(name: "flutter-webrtc", package: "flutter_webrtc"),
+                .product(name: "WebRTC", package: "flutter_webrtc")
+            ]
+        )
+    ]
+)

--- a/ios/livekit_client/Package.swift
+++ b/ios/livekit_client/Package.swift
@@ -1,4 +1,19 @@
 // swift-tools-version: 5.9
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import PackageDescription
 
 let package = Package(

--- a/ios/livekit_client/Sources/livekit_client/AVAudioPCMBuffer.swift
+++ b/ios/livekit_client/Sources/livekit_client/AVAudioPCMBuffer.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/AVAudioPCMBuffer.swift

--- a/ios/livekit_client/Sources/livekit_client/AudioConverter.swift
+++ b/ios/livekit_client/Sources/livekit_client/AudioConverter.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/AudioConverter.swift

--- a/ios/livekit_client/Sources/livekit_client/AudioProcessing.swift
+++ b/ios/livekit_client/Sources/livekit_client/AudioProcessing.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/AudioProcessing.swift

--- a/ios/livekit_client/Sources/livekit_client/AudioRenderer.swift
+++ b/ios/livekit_client/Sources/livekit_client/AudioRenderer.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/AudioRenderer.swift

--- a/ios/livekit_client/Sources/livekit_client/AudioTrack.swift
+++ b/ios/livekit_client/Sources/livekit_client/AudioTrack.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/AudioTrack.swift

--- a/ios/livekit_client/Sources/livekit_client/BroadcastBundleInfo.swift
+++ b/ios/livekit_client/Sources/livekit_client/BroadcastBundleInfo.swift
@@ -1,0 +1,1 @@
+../../../Classes/BroadcastBundleInfo.swift

--- a/ios/livekit_client/Sources/livekit_client/BroadcastManager.swift
+++ b/ios/livekit_client/Sources/livekit_client/BroadcastManager.swift
@@ -1,0 +1,1 @@
+../../../Classes/BroadcastManager.swift

--- a/ios/livekit_client/Sources/livekit_client/BundleInfo.swift
+++ b/ios/livekit_client/Sources/livekit_client/BundleInfo.swift
@@ -1,0 +1,1 @@
+../../../Classes/BundleInfo.swift

--- a/ios/livekit_client/Sources/livekit_client/DarwinNotificationCenter.swift
+++ b/ios/livekit_client/Sources/livekit_client/DarwinNotificationCenter.swift
@@ -1,0 +1,1 @@
+../../../Classes/DarwinNotificationCenter.swift

--- a/ios/livekit_client/Sources/livekit_client/FFTProcessor.swift
+++ b/ios/livekit_client/Sources/livekit_client/FFTProcessor.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/FFTProcessor.swift

--- a/ios/livekit_client/Sources/livekit_client/LiveKitPlugin.swift
+++ b/ios/livekit_client/Sources/livekit_client/LiveKitPlugin.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/LiveKitPlugin.swift

--- a/ios/livekit_client/Sources/livekit_client/LocalAudioTrack.swift
+++ b/ios/livekit_client/Sources/livekit_client/LocalAudioTrack.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/LocalAudioTrack.swift

--- a/ios/livekit_client/Sources/livekit_client/RemoteAudioTrack.swift
+++ b/ios/livekit_client/Sources/livekit_client/RemoteAudioTrack.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/RemoteAudioTrack.swift

--- a/ios/livekit_client/Sources/livekit_client/RingBuffer.swift
+++ b/ios/livekit_client/Sources/livekit_client/RingBuffer.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/RingBuffer.swift

--- a/ios/livekit_client/Sources/livekit_client/Track.swift
+++ b/ios/livekit_client/Sources/livekit_client/Track.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/Track.swift

--- a/ios/livekit_client/Sources/livekit_client/Visualizer.swift
+++ b/ios/livekit_client/Sources/livekit_client/Visualizer.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/Visualizer.swift

--- a/macos/livekit_client/Package.swift
+++ b/macos/livekit_client/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "livekit_client",
+    platforms: [
+        .macOS("10.15")
+    ],
+    products: [
+        .library(name: "livekit-client", targets: ["livekit_client"])
+    ],
+    dependencies: [
+        .package(name: "FlutterFramework", path: "../FlutterFramework"),
+        // Resolved by the Flutter tool to the flutter_webrtc plugin package.
+        .package(name: "flutter_webrtc", path: "../flutter_webrtc")
+    ],
+    targets: [
+        .target(
+            name: "livekit_client",
+            dependencies: [
+                .product(name: "FlutterFramework", package: "FlutterFramework"),
+                .product(name: "flutter-webrtc", package: "flutter_webrtc"),
+                .product(name: "WebRTC", package: "flutter_webrtc")
+            ]
+        )
+    ]
+)

--- a/macos/livekit_client/Package.swift
+++ b/macos/livekit_client/Package.swift
@@ -1,4 +1,19 @@
 // swift-tools-version: 5.9
+/*
+ * Copyright 2026 LiveKit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import PackageDescription
 
 let package = Package(

--- a/macos/livekit_client/Sources/livekit_client/AVAudioPCMBuffer.swift
+++ b/macos/livekit_client/Sources/livekit_client/AVAudioPCMBuffer.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/AVAudioPCMBuffer.swift

--- a/macos/livekit_client/Sources/livekit_client/AudioConverter.swift
+++ b/macos/livekit_client/Sources/livekit_client/AudioConverter.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/AudioConverter.swift

--- a/macos/livekit_client/Sources/livekit_client/AudioProcessing.swift
+++ b/macos/livekit_client/Sources/livekit_client/AudioProcessing.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/AudioProcessing.swift

--- a/macos/livekit_client/Sources/livekit_client/AudioRenderer.swift
+++ b/macos/livekit_client/Sources/livekit_client/AudioRenderer.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/AudioRenderer.swift

--- a/macos/livekit_client/Sources/livekit_client/AudioTrack.swift
+++ b/macos/livekit_client/Sources/livekit_client/AudioTrack.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/AudioTrack.swift

--- a/macos/livekit_client/Sources/livekit_client/FFTProcessor.swift
+++ b/macos/livekit_client/Sources/livekit_client/FFTProcessor.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/FFTProcessor.swift

--- a/macos/livekit_client/Sources/livekit_client/LiveKitPlugin.swift
+++ b/macos/livekit_client/Sources/livekit_client/LiveKitPlugin.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/LiveKitPlugin.swift

--- a/macos/livekit_client/Sources/livekit_client/LocalAudioTrack.swift
+++ b/macos/livekit_client/Sources/livekit_client/LocalAudioTrack.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/LocalAudioTrack.swift

--- a/macos/livekit_client/Sources/livekit_client/RemoteAudioTrack.swift
+++ b/macos/livekit_client/Sources/livekit_client/RemoteAudioTrack.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/RemoteAudioTrack.swift

--- a/macos/livekit_client/Sources/livekit_client/RingBuffer.swift
+++ b/macos/livekit_client/Sources/livekit_client/RingBuffer.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/RingBuffer.swift

--- a/macos/livekit_client/Sources/livekit_client/Track.swift
+++ b/macos/livekit_client/Sources/livekit_client/Track.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/Track.swift

--- a/macos/livekit_client/Sources/livekit_client/Visualizer.swift
+++ b/macos/livekit_client/Sources/livekit_client/Visualizer.swift
@@ -1,0 +1,1 @@
+../../../../shared_swift/Visualizer.swift

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -292,10 +292,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_webrtc
-      sha256: "0f89dee7f4c35dab5611f351c3897a3bfe9f7057720cc7da209b52455af4316e"
+      sha256: e997161d7da3adedd3d430691b20931b0b4d96fa48bb60938d9ba0bf6fca98be
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.2"
+    version: "1.6.0"
   frontend_server_client:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,7 +52,7 @@ dependencies:
   json_annotation: ^4.9.0
 
   # Fix version to avoid version conflicts between WebRTC-SDK pods, which both this package and flutter_webrtc depend on.
-  flutter_webrtc: 1.5.2
+  flutter_webrtc: 1.6.0
   dart_webrtc: ^1.8.0
 
 dev_dependencies:


### PR DESCRIPTION
## What

Adds Swift Package Manager support for the iOS and macOS plugins, following the Flutter SPM plugin convention:

- `ios/livekit_client/Package.swift` and `macos/livekit_client/Package.swift`, with `Sources/livekit_client/` symlink trees into `shared_swift/` (and the iOS broadcast files in `ios/Classes/`), so the existing sources stay the single source of truth.
- The packages depend on flutter_webrtc's Swift package (`../flutter_webrtc`, resolved by the Flutter tool) and consume its `flutter-webrtc` and `WebRTC` products. Reusing flutter_webrtc's WebRTC binary target keeps a single copy of the xcframework in the package graph, mirroring how the podspecs share the WebRTC-SDK pod today.
- The example app's Xcode projects get the SPM integration committed (package reference, product dependency, prepare pre-action in the Runner scheme), matching what `flutter` would generate.

CocoaPods is unchanged: podspecs and `Classes/` are untouched, and apps with SPM disabled keep building through pods.

## Depends on

- flutter-webrtc/flutter-webrtc#2062, including the `WebRTC` library product export. **This PR can only land after a flutter_webrtc release that ships SPM support**, at which point the pinned flutter_webrtc version needs a bump.

## Testing

With Flutter 3.44.1 (SPM on by default) and a local `dependency_overrides` pointing flutter_webrtc at the PR 2062 branch:

- `flutter build macos --debug` and `flutter build ios --debug --simulator` of the example both succeed.
- Both plugins compile as Swift packages (verified `LiveKitPlugin` / `FlutterWebRTCPlugin` symbols in the app binaries) with exactly one embedded `WebRTC.framework`.
- `permission_handler_apple` has no SPM support and keeps building through CocoaPods in hybrid mode.

Note for local testing: the Flutter tool copies plugins that declare SwiftPM dependencies on other plugins into the app's build directory with rsync. With the example app living inside this repo that copy recurses into itself (flutter_tools bug, to be filed upstream). Workaround is to make `example/build` a symlink to a directory outside the repo before building.

---

## Update 2026-08-03

flutter_webrtc 1.6.0 shipped with Swift Package Manager support, so this PR is unblocked:

- Bumped the pinned flutter_webrtc to 1.6.0 and removed the need for any local overrides. Verified the example builds via SPM against the released package from pub.dev, including the versioned pub cache path rewrite.
- Added a CI step to the iOS and macOS jobs that symlinks example/build outside the repository, working around the Flutter tool's rsync recursion when a plugin with SwiftPM plugin dependencies hosts its own example app (upstream flutter_tools bug, to be filed).
- Merged main (RPC tester, data stream fix, Dart 3.13 fixes).
