### PR TITLE
fix: compile errors on Dart 3.13 from stricter flow analysis

### DIFF
--- a/.changes/fix-dart313-flow-analysis
+++ b/.changes/fix-dart313-flow-analysis
@@ -1,0 +1,1 @@
+patch type="fixed" "Fix compile errors on Dart 3.13 where nullable publish options are no longer promoted across await"

--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -196,15 +196,15 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
         if (publishOptions.preConnect) lk_models.AudioTrackFeature.TF_PRECONNECT_BUFFER,
       ]);
 
-      Future<lk_models.TrackInfo> negotiate() async {
-        track.transceiver = await room.engine.createTransceiverRTCRtpSender(track, publishOptions!, encodings);
+      Future<lk_models.TrackInfo> negotiate(AudioPublishOptions options) async {
+        track.transceiver = await room.engine.createTransceiverRTCRtpSender(track, options, encodings);
         await room.engine.negotiate();
         return lk_models.TrackInfo();
       }
 
       late lk_models.TrackInfo trackInfo;
       if (room.engine.enabledPublishCodecs?.isNotEmpty ?? false) {
-        final rets = await Future.wait<lk_models.TrackInfo>([room.engine.addTrack(req), negotiate()]);
+        final rets = await Future.wait<lk_models.TrackInfo>([room.engine.addTrack(req), negotiate(publishOptions)]);
         trackInfo = rets[0];
       } else {
         trackInfo = await room.engine.addTrack(req);
@@ -378,31 +378,31 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
 
     logger.fine('Video layers: ${layers.map((e) => e)}');
 
-    Future<lk_models.TrackInfo> negotiate() async {
-      track.transceiver = await room.engine.createTransceiverRTCRtpSender(track, publishOptions!, encodings);
+    Future<lk_models.TrackInfo> negotiate(VideoPublishOptions options) async {
+      track.transceiver = await room.engine.createTransceiverRTCRtpSender(track, options, encodings);
 
-      track.codec = publishOptions.videoCodec;
+      track.codec = options.videoCodec;
       if (lkBrowser() != BrowserType.firefox) {
         await room.engine.setPreferredCodec(
           track.transceiver!,
           'video',
-          publishOptions.videoCodec,
+          options.videoCodec,
         );
       }
 
       if ([TrackSource.camera, TrackSource.screenShareVideo].contains(track.source)) {
-        final degradationPreference = publishOptions.degradationPreference ?? DegradationPreference.maintainResolution;
+        final degradationPreference = options.degradationPreference ?? DegradationPreference.maintainResolution;
         await track.setDegradationPreference(degradationPreference);
       }
 
       if (kIsWeb && lkBrowser() == BrowserType.firefox && track.kind == TrackType.AUDIO) {
         //TOOD:
-      } else if (isVideoCodec(publishOptions.videoCodec) && encodings?.first.maxBitrate != null) {
+      } else if (isVideoCodec(options.videoCodec) && encodings?.first.maxBitrate != null) {
         // Apply start bitrate for all video codecs to prevent initial blurriness
         room.engine.publisher?.setTrackBitrateInfo(TrackBitrateInfo(
             cid: track.getCid(),
             transceiver: track.transceiver,
-            codec: publishOptions.videoCodec,
+            codec: options.videoCodec,
             maxbr: encodings![0].maxBitrate! ~/ 1000));
       }
 
@@ -438,7 +438,7 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
     }
     late lk_models.TrackInfo trackInfo;
     if (room.engine.enabledPublishCodecs?.isNotEmpty ?? false) {
-      final rets = await Future.wait<lk_models.TrackInfo>([room.engine.addTrack(req), negotiate()]);
+      final rets = await Future.wait<lk_models.TrackInfo>([room.engine.addTrack(req), negotiate(publishOptions)]);
       trackInfo = rets[0];
     } else {
       trackInfo = await room.engine.addTrack(req);


### PR DESCRIPTION
## What

Dart 3.13 (shipping with Flutter 3.47, currently in beta) no longer keeps null promotion of captured variables across `await`. The video `negotiate()` closure in `LocalParticipant` dereferences the captured nullable `publishOptions` after an `await`, which now fails to compile:

```
lib/src/participant/local.dart:384: Error: Property 'videoCodec' cannot be accessed on 'VideoPublishOptions?' because it is potentially null.
Info: Variable 'publishOptions' could not be promoted due to an 'await' or 'yield'.
```

This breaks every app that depends on `livekit_client` once users update to Flutter 3.47, including the agent starter example.

## Fix

Pass the publish options into the `negotiate()` closure as a non-nullable parameter instead of capturing the nullable variable. At both call sites `publishOptions` is already promoted non-null in the enclosing function body, so this needs no null assertions at all. The audio closure gets the same treatment for consistency, which removes the pre-existing `publishOptions!` there too.

## Verification

- `flutter analyze` on 3.47 beta goes from 5 errors to 0, and stays clean on stable 3.44
- All unit tests pass
- The agent starter example builds on 3.47 beta with this patch applied to the resolved package