### PR TITLE
feat: typed screen share helpers

### DIFF
--- a/.changes/screenshare-typed-api
+++ b/.changes/screenshare-typed-api
@@ -1,0 +1,1 @@
+minor type="added" "Add ScreenSelectDialog.show and Hardware.requestCapturePermission so apps can start screen share without importing flutter_webrtc"

--- a/.changes/screenshare-typed-api
+++ b/.changes/screenshare-typed-api
@@ -1,1 +1,1 @@
-minor type="added" "Add ScreenSelectDialog.show and Hardware.requestCapturePermission so apps can start screen share without importing flutter_webrtc"
+patch type="added" "Add ScreenSelectDialog.show and Hardware.requestCapturePermission so apps can start screen share without importing flutter_webrtc"

--- a/lib/src/hardware/hardware.dart
+++ b/lib/src/hardware/hardware.dart
@@ -16,6 +16,7 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
+import 'package:meta/meta.dart';
 
 import '../audio/audio_manager.dart';
 import '../audio/audio_session.dart';
@@ -167,6 +168,23 @@ class Hardware {
       'audio': false,
       'video': device != null ? constraints : true,
     });
+  }
+
+  /// Requests permission to capture the screen before starting a screen share.
+  ///
+  /// On Android this shows the MediaProjection consent dialog, on macOS it
+  /// triggers the screen recording permission check. Returns true when
+  /// permission was granted. On platforms that do not require an upfront
+  /// request this is a no-op that returns true, so it is safe to call
+  /// unconditionally.
+  ///
+  /// Experimental: this API may change in a future release.
+  @experimental
+  Future<bool> requestCapturePermission({bool fullScreenOnly = false}) async {
+    if (lkPlatformIs(PlatformType.android) || lkPlatformIs(PlatformType.macOS)) {
+      return rtc.Helper.requestCapturePermission(fullScreenOnly: fullScreenOnly);
+    }
+    return true;
   }
 
   dynamic _onDeviceChange(dynamic _) async {

--- a/lib/src/widgets/screen_select_dialog.dart
+++ b/lib/src/widgets/screen_select_dialog.dart
@@ -160,26 +160,35 @@ class ScreenSelectDialog extends Dialog {
   final List<StreamSubscription<rtc.DesktopCapturerSource>> _subscriptions = [];
   StateSetter? _stateSetter;
   Timer? _timer;
+  bool _disposed = false;
+
+  /// Idempotent so it can run again when the route is disposed, which covers
+  /// dismissals that bypass the buttons like a barrier tap or the back button.
+  void _disposeResources() {
+    _disposed = true;
+    _timer?.cancel();
+    for (final element in _subscriptions) {
+      unawaited(element.cancel());
+    }
+    _subscriptions.clear();
+  }
 
   Future<void> _ok(BuildContext context) async {
-    _timer?.cancel();
-    for (var element in _subscriptions) {
-      await element.cancel();
-    }
+    _disposeResources();
     Navigator.pop<rtc.DesktopCapturerSource>(context, _selectedSource);
   }
 
   Future<void> _cancel(BuildContext context) async {
-    _timer?.cancel();
-    for (var element in _subscriptions) {
-      await element.cancel();
-    }
+    _disposeResources();
     Navigator.pop<rtc.DesktopCapturerSource>(context, null);
   }
 
   Future<void> _getSources() async {
     try {
       final sources = await rtc.desktopCapturer.getSources(types: [_sourceType]);
+      // The dialog may have been dismissed while getSources was in flight,
+      // starting the refresh timer now would leak it.
+      if (_disposed) return;
       for (var element in sources) {
         if (kDebugMode) {
           print('name: ${element.name}, id: ${element.id}, type: ${element.type}');
@@ -204,6 +213,13 @@ class ScreenSelectDialog extends Dialog {
 
   @override
   Widget build(BuildContext context) {
+    return _DisposeOnUnmount(
+      onDispose: _disposeResources,
+      child: _buildContent(context),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
     return Material(
       type: MaterialType.transparency,
       child: Center(
@@ -346,4 +362,27 @@ class ScreenSelectDialog extends Dialog {
       )),
     );
   }
+}
+
+/// Runs [onDispose] when the widget leaves the tree, so the dialog cleans up
+/// no matter how its route is popped.
+class _DisposeOnUnmount extends StatefulWidget {
+  const _DisposeOnUnmount({required this.onDispose, required this.child});
+
+  final VoidCallback onDispose;
+  final Widget child;
+
+  @override
+  State<_DisposeOnUnmount> createState() => _DisposeOnUnmountState();
+}
+
+class _DisposeOnUnmountState extends State<_DisposeOnUnmount> {
+  @override
+  void dispose() {
+    widget.onDispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
 }

--- a/lib/src/widgets/screen_select_dialog.dart
+++ b/lib/src/widgets/screen_select_dialog.dart
@@ -19,6 +19,7 @@ import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter/material.dart';
 
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
+import 'package:meta/meta.dart';
 
 class ThumbnailWidget extends StatefulWidget {
   const ThumbnailWidget({Key? key, required this.source, required this.selected, required this.onTap})
@@ -118,6 +119,33 @@ class ScreenSelectDialog extends Dialog {
     _subscriptions.add(rtc.desktopCapturer.onThumbnailChanged.stream.listen((source) {
       _stateSetter?.call(() {});
     }));
+  }
+
+  /// Shows the picker and returns the id of the selected capture source, or
+  /// null if the user cancelled. Pass the returned id to
+  /// [ScreenShareCaptureOptions.sourceId] when creating a screen share track.
+  ///
+  /// Experimental: this API may change in a future release.
+  @experimental
+  static Future<String?> show(
+    BuildContext context, {
+    String titleText = 'Choose what to share',
+    String screenTabText = 'Entire Screen',
+    String windowTabText = 'Window',
+    String cancelText = 'Cancel',
+    String shareText = 'Share',
+  }) async {
+    final source = await showDialog<rtc.DesktopCapturerSource>(
+      context: context,
+      builder: (context) => ScreenSelectDialog(
+        titleText: titleText,
+        screenTabText: screenTabText,
+        windowTabText: windowTabText,
+        cancelText: cancelText,
+        shareText: shareText,
+      ),
+    );
+    return source?.id;
   }
 
   final String titleText;


### PR DESCRIPTION
## What

Two small additive APIs, both marked experimental:

- `ScreenSelectDialog.show(context)` shows the existing desktop picker dialog and returns the selected source id as a `String?`, null when the user cancels. The id goes straight into `ScreenShareCaptureOptions.sourceId`.
- `Hardware.instance.requestCapturePermission({fullScreenOnly})` wraps the capture permission request on Android and macOS. On platforms that need no upfront request it returns true, so callers can use it unconditionally.

## Why

Starting a screen share currently forces downstream code to import `flutter_webrtc` directly for `DesktopCapturerSource` (the picker result type, which this SDK does not re-export) and `Helper.requestCapturePermission`. That is why `livekit_components` declares its own `flutter_webrtc` dependency with an exact version pin, and the pin drifting out of sync with ours is what currently downgrades users to livekit_client 2.6.1 (livekit/components-flutter#49, reported again via the agent starter example).

With these two helpers, components and apps can drive the whole screen share flow through `livekit_client` alone. The follow-up components release drops its `flutter_webrtc` dependency entirely, so this class of resolution conflict cannot recur.

## Notes

- No behavior change to the dialog itself, the static helper wraps the existing `showDialog` pattern
- The dialog customization params are threaded through `show()`
- Web safe, the example app compiles for web with these changes