### PR TITLE
chore: introduce DevelopmentTokenSource and deprecate SandboxTokenSource

### DIFF
--- a/.changes/development-token-source
+++ b/.changes/development-token-source
@@ -1,0 +1,1 @@
+minor type="added" "Add DevelopmentTokenSource, the new name for the now-deprecated SandboxTokenSource"

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -29,6 +29,10 @@ analyzer:
     - "**/*.pbjson.dart"
     - "**/*.pbserver.dart"
     # - 'web/*.dart'
+    # Xcode vendors Swift package checkouts under build when Swift Package
+    # Manager is enabled and this package ships Package.swift.
+    - build/**
+    - example/build/**
 
 linter:
   rules:

--- a/lib/livekit_client.dart
+++ b/lib/livekit_client.dart
@@ -88,7 +88,7 @@ export 'src/token_source/literal.dart';
 export 'src/token_source/endpoint.dart';
 export 'src/token_source/custom.dart';
 export 'src/token_source/caching.dart';
-export 'src/token_source/sandbox.dart';
+export 'src/token_source/development.dart';
 export 'src/token_source/jwt.dart';
 
 /// Misspelled alias for [kRpcVersion]. Kept for backwards compatibility with code

--- a/lib/src/token_source/development.dart
+++ b/lib/src/token_source/development.dart
@@ -17,7 +17,7 @@ import 'endpoint.dart';
 /// A token source that queries LiveKit's development token server for development and testing.
 ///
 /// This token source connects to LiveKit Cloud's
-/// [development token server](https://cloud.livekit.io/projects/p_/sandbox/templates/token-server),
+/// [development token server](https://docs.livekit.io/frontends/build/authentication/sandbox-token-server/),
 /// which is perfect for quick prototyping and getting started with LiveKit development.
 ///
 /// **Warning:** This token source is **insecure** and should **never** be used in production.

--- a/lib/src/token_source/development.dart
+++ b/lib/src/token_source/development.dart
@@ -14,30 +14,42 @@
 
 import 'endpoint.dart';
 
-/// A token source that queries LiveKit's sandbox token server for development and testing.
+/// A token source that queries LiveKit's development token server for development and testing.
 ///
-/// This token source connects to LiveKit Cloud's sandbox environment, which is perfect for
-/// quick prototyping and getting started with LiveKit development.
+/// This token source connects to LiveKit Cloud's
+/// [development token server](https://cloud.livekit.io/projects/p_/sandbox/templates/token-server),
+/// which is perfect for quick prototyping and getting started with LiveKit development.
 ///
 /// **Warning:** This token source is **insecure** and should **never** be used in production.
 ///
 /// For production use, implement [EndpointTokenSource] with your own backend or use [CustomTokenSource].
-class SandboxTokenSource extends EndpointTokenSource {
+class DevelopmentTokenSource extends EndpointTokenSource {
+  /// Initialize with a development token server ID from LiveKit Cloud.
+  ///
+  /// The [id] is obtained from your LiveKit Cloud project's token server settings.
+  DevelopmentTokenSource({
+    required String id,
+  }) : super(
+          url: Uri.parse('https://cloud-api.livekit.io/api/v2/sandbox/connection-details'),
+          headers: {
+            'X-Sandbox-ID': _sanitizeId(id),
+          },
+        );
+}
+
+/// A token source that queries LiveKit's sandbox token server for development and testing.
+@Deprecated('Use DevelopmentTokenSource instead')
+class SandboxTokenSource extends DevelopmentTokenSource {
   /// Initialize with a sandbox ID from LiveKit Cloud.
   ///
   /// The [sandboxId] is obtained from your LiveKit Cloud project's sandbox settings.
   SandboxTokenSource({
     required String sandboxId,
-  }) : super(
-          url: Uri.parse('https://cloud-api.livekit.io/api/v2/sandbox/connection-details'),
-          headers: {
-            'X-Sandbox-ID': _sanitizeSandboxId(sandboxId),
-          },
-        );
+  }) : super(id: sandboxId);
 }
 
-String _sanitizeSandboxId(String sandboxId) {
-  var sanitized = sandboxId;
+String _sanitizeId(String id) {
+  var sanitized = id;
   sanitized = sanitized.replaceFirst(RegExp(r'^[^a-zA-Z0-9]+'), '');
   sanitized = sanitized.replaceFirst(RegExp(r'[^a-zA-Z0-9]+$'), '');
   return sanitized;

--- a/lib/src/token_source/token_source.dart
+++ b/lib/src/token_source/token_source.dart
@@ -199,7 +199,7 @@ abstract class TokenSourceFixed {
 /// production applications that need flexible authentication and room management.
 ///
 /// Common implementations:
-/// - [SandboxTokenSource]: For testing with LiveKit Cloud sandbox token server
+/// - [DevelopmentTokenSource]: For testing with LiveKit Cloud development token server
 /// - [EndpointTokenSource]: For custom backend endpoints using LiveKit's JSON format
 /// - [CachingTokenSource]: For caching credentials (or use the `.cached()` extension method)
 abstract class TokenSourceConfigurable {

--- a/test/token/token_source_test.dart
+++ b/test/token/token_source_test.dart
@@ -16,10 +16,10 @@ import 'package:dart_jsonwebtoken/dart_jsonwebtoken.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:livekit_client/src/token_source/custom.dart';
+import 'package:livekit_client/src/token_source/development.dart';
 import 'package:livekit_client/src/token_source/jwt.dart';
 import 'package:livekit_client/src/token_source/literal.dart';
 import 'package:livekit_client/src/token_source/room_configuration.dart';
-import 'package:livekit_client/src/token_source/sandbox.dart';
 import 'package:livekit_client/src/token_source/token_source.dart';
 
 void main() {
@@ -248,8 +248,18 @@ void main() {
     });
   });
 
+  group('DevelopmentTokenSource', () {
+    test('sanitizes id and uses default base URL', () {
+      final source = DevelopmentTokenSource(id: '  sandbox-123  ');
+
+      expect(source.uri.toString(), 'https://cloud-api.livekit.io/api/v2/sandbox/connection-details');
+      expect(source.headers['X-Sandbox-ID'], 'sandbox-123');
+    });
+  });
+
   group('SandboxTokenSource', () {
-    test('sanitizes sandbox id and uses default base URL', () {
+    test('deprecated alias keeps the old constructor shape', () {
+      // ignore: deprecated_member_use_from_same_package
       final source = SandboxTokenSource(sandboxId: '  sandbox-123  ');
 
       expect(source.uri.toString(), 'https://cloud-api.livekit.io/api/v2/sandbox/connection-details');


### PR DESCRIPTION
## What

Port of livekit/client-sdk-swift#1077. LiveKit Cloud renamed the sandbox token server to the development token server, this aligns the API:

- `DevelopmentTokenSource({required String id})` is the new name, same endpoint and header
- `SandboxTokenSource` remains as a deprecated subclass. Unlike Swift, a typealias is not enough here because the old constructor takes `sandboxId:` while the new one takes `id:`, so the subclass keeps existing call sites compiling unchanged
- Doc references updated to the development token server wording

Also excludes `build/` from analysis, Xcode vendors Swift package checkouts there when SPM is enabled (same fix already applied to components-flutter and the agent starter).

## Notes

- Changeset: `minor type="added"`
- The JS SDK has the same concept (`TokenSource.sandboxTokenServer`) and has not been renamed yet, tracked separately