### PR TITLE
fix: Room.getSid() never resolves when the JoinResponse carries an empty room sid

### DIFF
--- a/.changes/room-getsid-wrong-emitter
+++ b/.changes/room-getsid-wrong-emitter
@@ -1,0 +1,1 @@
+patch type="fixed" "Room.getSid() now resolves when the room sid is issued after the join response"

--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -1107,14 +1107,13 @@ extension RoomPrivateMethods on Room {
     // consumed by _setUpSignalListeners) — it never appears on the Room's
     // [events], so listen where it actually fires or the future returned
     // here never completes.
-    final cancelRoomUpdateListen =
-        engine.signalClient.events.on<SignalRoomUpdateEvent>((event) {
+    final cancelRoomUpdateListen = engine.signalClient.events.on<SignalRoomUpdateEvent>((event) {
       if (event.room.sid.isNotEmpty && !completer.isCompleted) {
         completer.complete(event.room.sid);
       }
     });
 
-    events.once<RoomDisconnectedEvent>((event) {
+    final cancelDisconnectListen = events.once<RoomDisconnectedEvent>((event) {
       if (!completer.isCompleted) {
         completer.complete('');
       }
@@ -1126,7 +1125,10 @@ extension RoomPrivateMethods on Room {
       completer.complete(_roomInfo!.sid);
     }
 
-    return completer.future.whenComplete(cancelRoomUpdateListen);
+    return completer.future.whenComplete(() {
+      cancelRoomUpdateListen();
+      cancelDisconnectListen?.call();
+    });
   }
 }
 

--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -1125,9 +1125,9 @@ extension RoomPrivateMethods on Room {
       completer.complete(_roomInfo!.sid);
     }
 
-    return completer.future.whenComplete(() {
-      cancelRoomUpdateListen();
-      cancelDisconnectListen?.call();
+    return completer.future.whenComplete(() async {
+      await cancelRoomUpdateListen();
+      await cancelDisconnectListen?.call();
     });
   }
 }

--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -1106,14 +1106,25 @@ extension RoomPrivateMethods on Room {
     // SignalRoomUpdateEvent is emitted on the signal client's emitter (and
     // consumed by _setUpSignalListeners) — it never appears on the Room's
     // [events], so listen where it actually fires or the future returned
-    // here never completes.
-    final cancelRoomUpdateListen = engine.signalClient.events.on<SignalRoomUpdateEvent>((event) {
+    // here never completes. Created via createListener() so it is cancelled
+    // with its owner.
+    final roomUpdateListener = engine.signalClient.createListener();
+    roomUpdateListener.on<SignalRoomUpdateEvent>((event) {
       if (event.room.sid.isNotEmpty && !completer.isCompleted) {
         completer.complete(event.room.sid);
       }
     });
 
     final cancelDisconnectListen = events.once<RoomDisconnectedEvent>((event) {
+      if (!completer.isCompleted) {
+        completer.complete('');
+      }
+    });
+
+    // Disposal without a disconnect event (Room.dispose during teardown)
+    // cancels the listeners above — complete instead of leaving the returned
+    // future pending forever.
+    onDispose(() async {
       if (!completer.isCompleted) {
         completer.complete('');
       }
@@ -1126,7 +1137,7 @@ extension RoomPrivateMethods on Room {
     }
 
     return completer.future.whenComplete(() async {
-      await cancelRoomUpdateListen();
+      await roomUpdateListener.dispose();
       await cancelDisconnectListen?.call();
     });
   }

--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -111,6 +111,12 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
 
   lk_models.Room? _roomInfo;
 
+  // Pending getSid() waiters, completed with '' at disposal so a Room.dispose
+  // without a disconnect event can't leave them hanging. Tracked as a field
+  // (and drained by the constructor's dispose routine) so repeated getSid()
+  // calls don't accumulate per-call onDispose closures.
+  final Set<Completer<String>> _pendingSidCompleters = {};
+
   /// a list of participants that are actively speaking, including local participant.
   UnmodifiableListView<Participant> get activeSpeakers => UnmodifiableListView<Participant>(_activeSpeakers);
   List<Participant> _activeSpeakers = [];
@@ -203,6 +209,13 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
     preConnectAudioBuffer = PreConnectAudioBuffer(this);
 
     onDispose(() async {
+      // complete pending getSid() waiters so they don't hang on teardown
+      for (final completer in _pendingSidCompleters) {
+        if (!completer.isCompleted) {
+          completer.complete('');
+        }
+      }
+      _pendingSidCompleters.clear();
       // clean up routine
       await _cleanUp();
       // reject any in-flight RPC calls
@@ -1122,13 +1135,10 @@ extension RoomPrivateMethods on Room {
     });
 
     // Disposal without a disconnect event (Room.dispose during teardown)
-    // cancels the listeners above — complete instead of leaving the returned
+    // cancels the listeners above — the constructor's dispose routine
+    // completes every tracked waiter with '' instead of leaving the returned
     // future pending forever.
-    onDispose(() async {
-      if (!completer.isCompleted) {
-        completer.complete('');
-      }
-    });
+    _pendingSidCompleters.add(completer);
 
     // The update may have been applied between the check above and the
     // listener registration.
@@ -1137,6 +1147,7 @@ extension RoomPrivateMethods on Room {
     }
 
     return completer.future.whenComplete(() async {
+      _pendingSidCompleters.remove(completer);
       await roomUpdateListener.dispose();
       await cancelDisconnectListen?.call();
     });

--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -1128,6 +1128,16 @@ extension RoomPrivateMethods on Room {
       }
     });
 
+    // A caller waiting while the connection is still being established: the
+    // sid may arrive inside the JoinResponse, which is applied via
+    // EngineJoinResponseEvent without a SignalRoomUpdateEvent.
+    final joinListener = engine.createListener();
+    joinListener.on<EngineJoinResponseEvent>((event) {
+      if (event.response.room.sid.isNotEmpty && !completer.isCompleted) {
+        completer.complete(event.response.room.sid);
+      }
+    });
+
     final cancelDisconnectListen = events.once<RoomDisconnectedEvent>((event) {
       if (!completer.isCompleted) {
         completer.complete('');
@@ -1149,6 +1159,7 @@ extension RoomPrivateMethods on Room {
     return completer.future.whenComplete(() async {
       _pendingSidCompleters.remove(completer);
       await roomUpdateListener.dispose();
+      await joinListener.dispose();
       await cancelDisconnectListen?.call();
     });
   }

--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -1103,7 +1103,12 @@ extension RoomPrivateMethods on Room {
 
     final completer = Completer<String>();
 
-    events.on<SignalRoomUpdateEvent>((event) {
+    // SignalRoomUpdateEvent is emitted on the signal client's emitter (and
+    // consumed by _setUpSignalListeners) — it never appears on the Room's
+    // [events], so listen where it actually fires or the future returned
+    // here never completes.
+    final cancelRoomUpdateListen =
+        engine.signalClient.events.on<SignalRoomUpdateEvent>((event) {
       if (event.room.sid.isNotEmpty && !completer.isCompleted) {
         completer.complete(event.room.sid);
       }
@@ -1115,7 +1120,13 @@ extension RoomPrivateMethods on Room {
       }
     });
 
-    return completer.future;
+    // The update may have been applied between the check above and the
+    // listener registration.
+    if (_roomInfo != null && _roomInfo!.sid.isNotEmpty && !completer.isCompleted) {
+      completer.complete(_roomInfo!.sid);
+    }
+
+    return completer.future.whenComplete(cancelRoomUpdateListen);
   }
 }
 

--- a/test/core/room_sid_test.dart
+++ b/test/core/room_sid_test.dart
@@ -1,0 +1,109 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@Timeout(Duration(seconds: 5))
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:livekit_client/livekit_client.dart';
+import 'package:livekit_client/src/proto/livekit_models.pb.dart' as lk_models;
+import 'package:livekit_client/src/proto/livekit_rtc.pb.dart' as lk_rtc;
+import '../mock/e2e_container.dart';
+import '../mock/test_data.dart';
+import 'signal_client_test.dart';
+
+/// Room sids are assigned asynchronously by the server: the JoinResponse can
+/// carry an empty `room.sid`, with the real sid following in a RoomUpdate.
+/// `getSid()` must resolve when that update arrives — it used to wait for
+/// `SignalRoomUpdateEvent` on the Room's own emitter, where that (signal)
+/// event is never emitted, so the returned future never completed.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final lk_rtc.SignalResponse emptySidJoinResponse = lk_rtc.SignalResponse(
+    join: lk_rtc.JoinResponse(
+      room: lk_models.Room(
+        name: 'room_name',
+        // sid deliberately unset — issued later via RoomUpdate.
+      ),
+      participant: localParticipantData,
+      subscriberPrimary: true,
+      serverVersion: '99.999',
+      serverInfo: lk_models.ServerInfo(
+        version: '1.8.0',
+      ),
+    ),
+  );
+
+  final lk_rtc.SignalResponse sidRoomUpdateResponse = lk_rtc.SignalResponse(
+    roomUpdate: lk_rtc.RoomUpdate(
+      room: lk_models.Room(
+        name: 'room_name',
+        sid: 'RM_issued_later',
+      ),
+    ),
+  );
+
+  /// Connects the container's room, answering with [joinResp] instead of the
+  /// default join response.
+  Future<void> connectWith(
+      E2EContainer container, lk_rtc.SignalResponse joinResp) async {
+    final connectFuture = container.room.connect(exampleUri, token);
+    Future.delayed(const Duration(milliseconds: 1), () {
+      container.wsConnector.onData(joinResp.writeToBuffer());
+      container.wsConnector.onData(offerResponse.writeToBuffer());
+    });
+    await connectFuture;
+  }
+
+  late E2EContainer container;
+
+  setUp(() async {
+    container = E2EContainer();
+  });
+
+  tearDown(() async {
+    await container.dispose();
+  });
+
+  group('Room.getSid', () {
+    test('returns immediately when the join response carried the sid',
+        () async {
+      await connectWith(container, joinResponse);
+
+      expect(await container.room.getSid(), 'room_sid');
+    });
+
+    test('resolves when the sid arrives via a later RoomUpdate', () async {
+      await connectWith(container, emptySidJoinResponse);
+
+      final sidFuture = container.room.getSid();
+      container.wsConnector.onData(sidRoomUpdateResponse.writeToBuffer());
+
+      expect(await sidFuture, 'RM_issued_later');
+    });
+
+    test('resolves for a caller arriving after the RoomUpdate landed',
+        () async {
+      await connectWith(container, emptySidJoinResponse);
+
+      container.wsConnector.onData(sidRoomUpdateResponse.writeToBuffer());
+      // Let the signal event propagate to _applyRoomUpdate.
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(await container.room.getSid(), 'RM_issued_later');
+    });
+  });
+}

--- a/test/core/room_sid_test.dart
+++ b/test/core/room_sid_test.dart
@@ -58,8 +58,7 @@ void main() {
 
   /// Connects the container's room, answering with [joinResp] instead of the
   /// default join response.
-  Future<void> connectWith(
-      E2EContainer container, lk_rtc.SignalResponse joinResp) async {
+  Future<void> connectWith(E2EContainer container, lk_rtc.SignalResponse joinResp) async {
     final connectFuture = container.room.connect(exampleUri, token);
     Future.delayed(const Duration(milliseconds: 1), () {
       container.wsConnector.onData(joinResp.writeToBuffer());
@@ -79,8 +78,7 @@ void main() {
   });
 
   group('Room.getSid', () {
-    test('returns immediately when the join response carried the sid',
-        () async {
+    test('returns immediately when the join response carried the sid', () async {
       await connectWith(container, joinResponse);
 
       expect(await container.room.getSid(), 'room_sid');
@@ -95,8 +93,7 @@ void main() {
       expect(await sidFuture, 'RM_issued_later');
     });
 
-    test('resolves for a caller arriving after the RoomUpdate landed',
-        () async {
+    test('resolves for a caller arriving after the RoomUpdate landed', () async {
       await connectWith(container, emptySidJoinResponse);
 
       container.wsConnector.onData(sidRoomUpdateResponse.writeToBuffer());

--- a/test/core/room_sid_test.dart
+++ b/test/core/room_sid_test.dart
@@ -93,6 +93,15 @@ void main() {
       expect(await sidFuture, 'RM_issued_later');
     });
 
+    test('completes with an empty sid when the room is disposed while waiting', () async {
+      await connectWith(container, emptySidJoinResponse);
+
+      final sidFuture = container.room.getSid();
+      await container.room.dispose();
+
+      expect(await sidFuture, '');
+    });
+
     test('resolves for a caller arriving after the RoomUpdate landed', () async {
       await connectWith(container, emptySidJoinResponse);
 

--- a/test/core/room_sid_test.dart
+++ b/test/core/room_sid_test.dart
@@ -102,6 +102,19 @@ void main() {
       expect(await sidFuture, '');
     });
 
+    test('repeated calls do not accumulate dispose hooks', () async {
+      await connectWith(container, emptySidJoinResponse);
+      final hooksBefore = container.room.disposeFuncCount;
+
+      for (var i = 0; i < 3; i++) {
+        final sidFuture = container.room.getSid();
+        container.wsConnector.onData(sidRoomUpdateResponse.writeToBuffer());
+        await sidFuture;
+      }
+
+      expect(container.room.disposeFuncCount, hooksBefore);
+    });
+
     test('resolves for a caller arriving after the RoomUpdate landed', () async {
       await connectWith(container, emptySidJoinResponse);
 

--- a/test/core/room_sid_test.dart
+++ b/test/core/room_sid_test.dart
@@ -102,6 +102,20 @@ void main() {
       expect(await sidFuture, '');
     });
 
+    test('resolves with the join-response sid for callers waiting during connect', () async {
+      final connectFuture = container.room.connect(exampleUri, token);
+      Future.delayed(const Duration(milliseconds: 5), () {
+        container.wsConnector.onData(joinResponse.writeToBuffer());
+        container.wsConnector.onData(offerResponse.writeToBuffer());
+      });
+      // Ask while the signal connection is still being established.
+      await Future<void>.delayed(const Duration(milliseconds: 1));
+      final sidFuture = container.room.getSid();
+
+      await connectFuture;
+      expect(await sidFuture, 'room_sid');
+    });
+
     test('repeated calls do not accumulate dispose hooks', () async {
       await connectWith(container, emptySidJoinResponse);
       final hooksBefore = container.room.disposeFuncCount;


### PR DESCRIPTION
Fixes #1151

## What

`Room.getSid()` waited for `SignalRoomUpdateEvent` on the Room's event emitter, but that event is only ever emitted on the signal client's emitter (and consumed by `_setUpSignalListeners`) — so when the server issues the room sid asynchronously (empty `room.sid` in the JoinResponse, real sid in a later RoomUpdate), the returned future never completed.

This deadlocks any `await room.getSid()` during the post-join window. Most visibly: `livekit_noise_filter`'s `onPublish` awaits it while the SDK holds the `SerialRunner` publish lock inside `_publishAudioTrack` — the mic track publishes and audio flows, but `setMicrophoneEnabled(true)` never returns and **every subsequent mute/unmute queues forever behind the lock** (observed in production on macOS with LiveKit Cloud; full analysis in #1151).

## How

- Listen on `engine.signalClient.events`, where `SignalRoomUpdateEvent` actually fires.
- Re-check `_roomInfo` after registering the listener, closing the race with `_applyRoomUpdate` (update landing between the early-return check and listener setup).
- Cancel the listener when the future completes (the previous listener was never removed).

## Tests

New `test/core/room_sid_test.dart` (using the existing `E2EContainer` mock harness):

1. sid present in the JoinResponse → `getSid()` returns immediately (guard, passed before).
2. sid empty in the JoinResponse, issued via a later RoomUpdate while `getSid()` is pending → **times out on `main`, passes with this fix**.
3. caller arriving after the RoomUpdate landed → returns the cached sid (guard, passed before).

Full test suite green (373 tests), `flutter analyze` clean on the changed files.
