### PR TITLE
Surface newer server disconnect reasons as distinct DisconnectReason values

### DIFF
--- a/.changes/disconnect-reason-members
+++ b/.changes/disconnect-reason-members
@@ -1,0 +1,1 @@
+minor type="added" "DisconnectReason gained members for the newer server reasons (roomClosed, migration, signalClose, userUnavailable, userRejected, sipTrunkFailure, connectionTimeout, mediaFailure, agentError), previously reported as unknown"

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -249,6 +249,15 @@ extension DisconnectReasonExt on lk_models.DisconnectReason {
         lk_models.DisconnectReason.ROOM_DELETED => DisconnectReason.roomDeleted,
         lk_models.DisconnectReason.STATE_MISMATCH => DisconnectReason.stateMismatch,
         lk_models.DisconnectReason.JOIN_FAILURE => DisconnectReason.joinFailure,
+        lk_models.DisconnectReason.MIGRATION => DisconnectReason.migration,
+        lk_models.DisconnectReason.SIGNAL_CLOSE => DisconnectReason.signalClose,
+        lk_models.DisconnectReason.ROOM_CLOSED => DisconnectReason.roomClosed,
+        lk_models.DisconnectReason.USER_UNAVAILABLE => DisconnectReason.userUnavailable,
+        lk_models.DisconnectReason.USER_REJECTED => DisconnectReason.userRejected,
+        lk_models.DisconnectReason.SIP_TRUNK_FAILURE => DisconnectReason.sipTrunkFailure,
+        lk_models.DisconnectReason.CONNECTION_TIMEOUT => DisconnectReason.connectionTimeout,
+        lk_models.DisconnectReason.MEDIA_FAILURE => DisconnectReason.mediaFailure,
+        lk_models.DisconnectReason.AGENT_ERROR => DisconnectReason.agentError,
         _ => DisconnectReason.unknown,
       };
 }

--- a/lib/src/types/other.dart
+++ b/lib/src/types/other.dart
@@ -161,6 +161,15 @@ enum DisconnectReason {
   disconnected,
   signalingConnectionFailure,
   reconnectAttemptsExceeded,
+  migration,
+  signalClose,
+  roomClosed,
+  userUnavailable,
+  userRejected,
+  sipTrunkFailure,
+  connectionTimeout,
+  mediaFailure,
+  agentError,
 }
 
 /// The reason why a track failed to publish.

--- a/test/types/disconnect_reason_test.dart
+++ b/test/types/disconnect_reason_test.dart
@@ -1,0 +1,48 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:livekit_client/src/extensions.dart';
+import 'package:livekit_client/src/proto/livekit_models.pb.dart' as lk_models;
+import 'package:livekit_client/src/types/other.dart';
+
+void main() {
+  group('DisconnectReason.toSDKType', () {
+    test('maps every proto value to a distinct SDK value', () {
+      final mapped = <DisconnectReason>{};
+      for (final reason in lk_models.DisconnectReason.values) {
+        final sdkReason = reason.toSDKType();
+        expect(
+          mapped.contains(sdkReason),
+          isFalse,
+          reason: '$reason maps to $sdkReason which is already used by another proto value',
+        );
+        mapped.add(sdkReason);
+      }
+    });
+
+    test('maps newer server reasons to their own members', () {
+      expect(lk_models.DisconnectReason.ROOM_CLOSED.toSDKType(), DisconnectReason.roomClosed);
+      expect(lk_models.DisconnectReason.MIGRATION.toSDKType(), DisconnectReason.migration);
+      expect(lk_models.DisconnectReason.SIGNAL_CLOSE.toSDKType(), DisconnectReason.signalClose);
+      expect(lk_models.DisconnectReason.USER_UNAVAILABLE.toSDKType(), DisconnectReason.userUnavailable);
+      expect(lk_models.DisconnectReason.USER_REJECTED.toSDKType(), DisconnectReason.userRejected);
+      expect(lk_models.DisconnectReason.SIP_TRUNK_FAILURE.toSDKType(), DisconnectReason.sipTrunkFailure);
+      expect(lk_models.DisconnectReason.CONNECTION_TIMEOUT.toSDKType(), DisconnectReason.connectionTimeout);
+      expect(lk_models.DisconnectReason.MEDIA_FAILURE.toSDKType(), DisconnectReason.mediaFailure);
+      expect(lk_models.DisconnectReason.AGENT_ERROR.toSDKType(), DisconnectReason.agentError);
+    });
+  });
+}


### PR DESCRIPTION
Stacked on #1156, review that first. Only the last commit (`87a9753`) is new here.

The protocol defines 17 disconnect reasons but the public `DisconnectReason` enum only had members for 8 of them, so newer reasons arriving in a leave request (for example when the server closes a room or a SIP trunk fails) were all collapsed to `unknown`. This adds members for the nine missing reasons and maps them in `toSDKType`:

`migration`, `signalClose`, `roomClosed`, `userUnavailable`, `userRejected`, `sipTrunkFailure`, `connectionTimeout`, `mediaFailure`, `agentError`

Unrecognized values from servers newer than the SDK still fall back to `unknown` via the wildcard arm introduced in #1156.

Note for apps: adding enum members means an exhaustive `switch` over `DisconnectReason` in app code will need new cases, which is why the changeset is `minor`.

## Tests

New `test/types/disconnect_reason_test.dart` asserts every proto value maps to a distinct SDK value and pins the nine new mappings. Full suite passes (380 tests), analyze, format, and import sorter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
