### PR TITLE
chore: update generated protocol definitions to v1.50.4

### DIFF
--- a/.changes/update-protocol-v1-50-4
+++ b/.changes/update-protocol-v1-50-4
@@ -1,0 +1,1 @@
+patch type="changed" "Update generated protocol definitions to v1.50.4"

--- a/lib/src/proto/livekit_metrics.pb.dart
+++ b/lib/src/proto/livekit_metrics.pb.dart
@@ -434,6 +434,9 @@ class MetricsRecordingHeader extends $pb.GeneratedMessage {
     $core.Iterable<$core.MapEntry<$core.String, $core.String>>? roomTags,
     $core.String? roomName,
     $0.Timestamp? roomStartTime,
+    $core.String? jobId,
+    $core.bool? simulated,
+    $core.bool? redactionEnabled,
   }) {
     final result = create();
     if (roomId != null) result.roomId = roomId;
@@ -442,6 +445,9 @@ class MetricsRecordingHeader extends $pb.GeneratedMessage {
     if (roomTags != null) result.roomTags.addEntries(roomTags);
     if (roomName != null) result.roomName = roomName;
     if (roomStartTime != null) result.roomStartTime = roomStartTime;
+    if (jobId != null) result.jobId = jobId;
+    if (simulated != null) result.simulated = simulated;
+    if (redactionEnabled != null) result.redactionEnabled = redactionEnabled;
     return result;
   }
 
@@ -466,6 +472,9 @@ class MetricsRecordingHeader extends $pb.GeneratedMessage {
         packageName: const $pb.PackageName('livekit'))
     ..aOS(6, _omitFieldNames ? '' : 'roomName')
     ..aOM<$0.Timestamp>(7, _omitFieldNames ? '' : 'roomStartTime', subBuilder: $0.Timestamp.create)
+    ..aOS(8, _omitFieldNames ? '' : 'jobId')
+    ..aOB(9, _omitFieldNames ? '' : 'simulated')
+    ..aOB(10, _omitFieldNames ? '' : 'redactionEnabled')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -537,6 +546,33 @@ class MetricsRecordingHeader extends $pb.GeneratedMessage {
   void clearRoomStartTime() => $_clearField(7);
   @$pb.TagNumber(7)
   $0.Timestamp ensureRoomStartTime() => $_ensure(5);
+
+  @$pb.TagNumber(8)
+  $core.String get jobId => $_getSZ(6);
+  @$pb.TagNumber(8)
+  set jobId($core.String value) => $_setString(6, value);
+  @$pb.TagNumber(8)
+  $core.bool hasJobId() => $_has(6);
+  @$pb.TagNumber(8)
+  void clearJobId() => $_clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.bool get simulated => $_getBF(7);
+  @$pb.TagNumber(9)
+  set simulated($core.bool value) => $_setBool(7, value);
+  @$pb.TagNumber(9)
+  $core.bool hasSimulated() => $_has(7);
+  @$pb.TagNumber(9)
+  void clearSimulated() => $_clearField(9);
+
+  @$pb.TagNumber(10)
+  $core.bool get redactionEnabled => $_getBF(8);
+  @$pb.TagNumber(10)
+  set redactionEnabled($core.bool value) => $_setBool(8, value);
+  @$pb.TagNumber(10)
+  $core.bool hasRedactionEnabled() => $_has(8);
+  @$pb.TagNumber(10)
+  void clearRedactionEnabled() => $_clearField(10);
 }
 
 const $core.bool _omitFieldNames = $core.bool.fromEnvironment('protobuf.omit_field_names');

--- a/lib/src/proto/livekit_metrics.pbjson.dart
+++ b/lib/src/proto/livekit_metrics.pbjson.dart
@@ -190,8 +190,14 @@ const MetricsRecordingHeader$json = {
     {'1': 'room_tags', '3': 5, '4': 3, '5': 11, '6': '.livekit.MetricsRecordingHeader.RoomTagsEntry', '10': 'roomTags'},
     {'1': 'room_name', '3': 6, '4': 1, '5': 9, '10': 'roomName'},
     {'1': 'room_start_time', '3': 7, '4': 1, '5': 11, '6': '.google.protobuf.Timestamp', '10': 'roomStartTime'},
+    {'1': 'job_id', '3': 8, '4': 1, '5': 9, '10': 'jobId'},
+    {'1': 'simulated', '3': 9, '4': 1, '5': 8, '10': 'simulated'},
+    {'1': 'redaction_enabled', '3': 10, '4': 1, '5': 8, '10': 'redactionEnabled'},
   ],
   '3': [MetricsRecordingHeader_RoomTagsEntry$json],
+  '9': [
+    {'1': 2, '2': 3},
+  ],
 };
 
 @$core.Deprecated('Use metricsRecordingHeaderDescriptor instead')
@@ -211,5 +217,7 @@ final $typed_data.Uint8List metricsRecordingHeaderDescriptor =
         'Z29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcFIJc3RhcnRUaW1lEkoKCXJvb21fdGFncxgFIAMoCz'
         'ItLmxpdmVraXQuTWV0cmljc1JlY29yZGluZ0hlYWRlci5Sb29tVGFnc0VudHJ5Ughyb29tVGFn'
         'cxIbCglyb29tX25hbWUYBiABKAlSCHJvb21OYW1lEkIKD3Jvb21fc3RhcnRfdGltZRgHIAEoCz'
-        'IaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBSDXJvb21TdGFydFRpbWUaOwoNUm9vbVRhZ3NF'
-        'bnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AjgB');
+        'IaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBSDXJvb21TdGFydFRpbWUSFQoGam9iX2lkGAgg'
+        'ASgJUgVqb2JJZBIcCglzaW11bGF0ZWQYCSABKAhSCXNpbXVsYXRlZBIrChFyZWRhY3Rpb25fZW'
+        '5hYmxlZBgKIAEoCFIQcmVkYWN0aW9uRW5hYmxlZBo7Cg1Sb29tVGFnc0VudHJ5EhAKA2tleRgB'
+        'IAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAFKBAgCEAM=');

--- a/lib/src/proto/livekit_models.pb.dart
+++ b/lib/src/proto/livekit_models.pb.dart
@@ -728,6 +728,7 @@ class ParticipantInfo extends $pb.GeneratedMessage {
     $core.Iterable<ParticipantInfo_KindDetail>? kindDetails,
     $core.Iterable<DataTrackInfo>? dataTracks,
     $core.int? clientProtocol,
+    $core.Iterable<ClientInfo_Capability>? capabilities,
   }) {
     final result = create();
     if (sid != null) result.sid = sid;
@@ -748,6 +749,7 @@ class ParticipantInfo extends $pb.GeneratedMessage {
     if (kindDetails != null) result.kindDetails.addAll(kindDetails);
     if (dataTracks != null) result.dataTracks.addAll(dataTracks);
     if (clientProtocol != null) result.clientProtocol = clientProtocol;
+    if (capabilities != null) result.capabilities.addAll(capabilities);
     return result;
   }
 
@@ -786,6 +788,10 @@ class ParticipantInfo extends $pb.GeneratedMessage {
         defaultEnumValue: ParticipantInfo_KindDetail.CLOUD_AGENT)
     ..pPM<DataTrackInfo>(19, _omitFieldNames ? '' : 'dataTracks', subBuilder: DataTrackInfo.create)
     ..aI(20, _omitFieldNames ? '' : 'clientProtocol')
+    ..pc<ClientInfo_Capability>(21, _omitFieldNames ? '' : 'capabilities', $pb.PbFieldType.KE,
+        valueOf: ClientInfo_Capability.valueOf,
+        enumValues: ClientInfo_Capability.values,
+        defaultEnumValue: ClientInfo_Capability.CAP_UNUSED)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -950,6 +956,11 @@ class ParticipantInfo extends $pb.GeneratedMessage {
   $core.bool hasClientProtocol() => $_has(17);
   @$pb.TagNumber(20)
   void clearClientProtocol() => $_clearField(20);
+
+  /// capabilities the participant's client advertises, mirrored from ClientInfo.
+  /// Lets other participants perform client-side feature detection.
+  @$pb.TagNumber(21)
+  $pb.PbList<ClientInfo_Capability> get capabilities => $_getList(18);
 }
 
 class Encryption extends $pb.GeneratedMessage {
@@ -1394,12 +1405,16 @@ class DataTrackInfo extends $pb.GeneratedMessage {
     $core.String? sid,
     $core.String? name,
     Encryption_Type? encryption,
+    DataTrackFrameEncoding? frameEncoding,
+    DataTrackSchemaId? schema,
   }) {
     final result = create();
     if (pubHandle != null) result.pubHandle = pubHandle;
     if (sid != null) result.sid = sid;
     if (name != null) result.name = name;
     if (encryption != null) result.encryption = encryption;
+    if (frameEncoding != null) result.frameEncoding = frameEncoding;
+    if (schema != null) result.schema = schema;
     return result;
   }
 
@@ -1417,6 +1432,8 @@ class DataTrackInfo extends $pb.GeneratedMessage {
     ..aOS(2, _omitFieldNames ? '' : 'sid')
     ..aOS(3, _omitFieldNames ? '' : 'name')
     ..aE<Encryption_Type>(4, _omitFieldNames ? '' : 'encryption', enumValues: Encryption_Type.values)
+    ..aOM<DataTrackFrameEncoding>(5, _omitFieldNames ? '' : 'frameEncoding', subBuilder: DataTrackFrameEncoding.create)
+    ..aOM<DataTrackSchemaId>(6, _omitFieldNames ? '' : 'schema', subBuilder: DataTrackSchemaId.create)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -1475,6 +1492,263 @@ class DataTrackInfo extends $pb.GeneratedMessage {
   $core.bool hasEncryption() => $_has(3);
   @$pb.TagNumber(4)
   void clearEncryption() => $_clearField(4);
+
+  /// Encoding for frame payloads on this track. If unspecified, the track is untyped.
+  @$pb.TagNumber(5)
+  DataTrackFrameEncoding get frameEncoding => $_getN(4);
+  @$pb.TagNumber(5)
+  set frameEncoding(DataTrackFrameEncoding value) => $_setField(5, value);
+  @$pb.TagNumber(5)
+  $core.bool hasFrameEncoding() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearFrameEncoding() => $_clearField(5);
+  @$pb.TagNumber(5)
+  DataTrackFrameEncoding ensureFrameEncoding() => $_ensure(4);
+
+  /// ID of the schema used by frames on this track if the track is typed.
+  @$pb.TagNumber(6)
+  DataTrackSchemaId get schema => $_getN(5);
+  @$pb.TagNumber(6)
+  set schema(DataTrackSchemaId value) => $_setField(6, value);
+  @$pb.TagNumber(6)
+  $core.bool hasSchema() => $_has(5);
+  @$pb.TagNumber(6)
+  void clearSchema() => $_clearField(6);
+  @$pb.TagNumber(6)
+  DataTrackSchemaId ensureSchema() => $_ensure(5);
+}
+
+enum DataTrackFrameEncoding_Value { wellKnown, custom, notSet }
+
+/// Encoding for frame payloads.
+class DataTrackFrameEncoding extends $pb.GeneratedMessage {
+  factory DataTrackFrameEncoding({
+    DataTrackFrameEncoding_WellKnownFrameEncoding? wellKnown,
+    $core.String? custom,
+  }) {
+    final result = create();
+    if (wellKnown != null) result.wellKnown = wellKnown;
+    if (custom != null) result.custom = custom;
+    return result;
+  }
+
+  DataTrackFrameEncoding._();
+
+  factory DataTrackFrameEncoding.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory DataTrackFrameEncoding.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static const $core.Map<$core.int, DataTrackFrameEncoding_Value> _DataTrackFrameEncoding_ValueByTag = {
+    1: DataTrackFrameEncoding_Value.wellKnown,
+    2: DataTrackFrameEncoding_Value.custom,
+    0: DataTrackFrameEncoding_Value.notSet
+  };
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DataTrackFrameEncoding',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'livekit'), createEmptyInstance: create)
+    ..oo(0, [1, 2])
+    ..aE<DataTrackFrameEncoding_WellKnownFrameEncoding>(1, _omitFieldNames ? '' : 'wellKnown',
+        enumValues: DataTrackFrameEncoding_WellKnownFrameEncoding.values)
+    ..aOS(2, _omitFieldNames ? '' : 'custom')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DataTrackFrameEncoding clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DataTrackFrameEncoding copyWith(void Function(DataTrackFrameEncoding) updates) =>
+      super.copyWith((message) => updates(message as DataTrackFrameEncoding)) as DataTrackFrameEncoding;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DataTrackFrameEncoding create() => DataTrackFrameEncoding._();
+  @$core.override
+  DataTrackFrameEncoding createEmptyInstance() => create();
+  @$core.pragma('dart2js:noInline')
+  static DataTrackFrameEncoding getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DataTrackFrameEncoding>(create);
+  static DataTrackFrameEncoding? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  @$pb.TagNumber(2)
+  DataTrackFrameEncoding_Value whichValue() => _DataTrackFrameEncoding_ValueByTag[$_whichOneof(0)]!;
+  @$pb.TagNumber(1)
+  @$pb.TagNumber(2)
+  void clearValue() => $_clearField($_whichOneof(0));
+
+  @$pb.TagNumber(1)
+  DataTrackFrameEncoding_WellKnownFrameEncoding get wellKnown => $_getN(0);
+  @$pb.TagNumber(1)
+  set wellKnown(DataTrackFrameEncoding_WellKnownFrameEncoding value) => $_setField(1, value);
+  @$pb.TagNumber(1)
+  $core.bool hasWellKnown() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWellKnown() => $_clearField(1);
+
+  /// Identifier of a custom encoding not covered by the well-known cases.
+  /// This must be non-empty and no longer than 32 characters.
+  @$pb.TagNumber(2)
+  $core.String get custom => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set custom($core.String value) => $_setString(1, value);
+  @$pb.TagNumber(2)
+  $core.bool hasCustom() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCustom() => $_clearField(2);
+}
+
+enum DataTrackSchemaEncoding_Value { wellKnown, custom, notSet }
+
+/// Encoding for schema definition.
+class DataTrackSchemaEncoding extends $pb.GeneratedMessage {
+  factory DataTrackSchemaEncoding({
+    DataTrackSchemaEncoding_WellKnownSchemaEncoding? wellKnown,
+    $core.String? custom,
+  }) {
+    final result = create();
+    if (wellKnown != null) result.wellKnown = wellKnown;
+    if (custom != null) result.custom = custom;
+    return result;
+  }
+
+  DataTrackSchemaEncoding._();
+
+  factory DataTrackSchemaEncoding.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory DataTrackSchemaEncoding.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static const $core.Map<$core.int, DataTrackSchemaEncoding_Value> _DataTrackSchemaEncoding_ValueByTag = {
+    1: DataTrackSchemaEncoding_Value.wellKnown,
+    2: DataTrackSchemaEncoding_Value.custom,
+    0: DataTrackSchemaEncoding_Value.notSet
+  };
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DataTrackSchemaEncoding',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'livekit'), createEmptyInstance: create)
+    ..oo(0, [1, 2])
+    ..aE<DataTrackSchemaEncoding_WellKnownSchemaEncoding>(1, _omitFieldNames ? '' : 'wellKnown',
+        enumValues: DataTrackSchemaEncoding_WellKnownSchemaEncoding.values)
+    ..aOS(2, _omitFieldNames ? '' : 'custom')
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DataTrackSchemaEncoding clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DataTrackSchemaEncoding copyWith(void Function(DataTrackSchemaEncoding) updates) =>
+      super.copyWith((message) => updates(message as DataTrackSchemaEncoding)) as DataTrackSchemaEncoding;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DataTrackSchemaEncoding create() => DataTrackSchemaEncoding._();
+  @$core.override
+  DataTrackSchemaEncoding createEmptyInstance() => create();
+  @$core.pragma('dart2js:noInline')
+  static DataTrackSchemaEncoding getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DataTrackSchemaEncoding>(create);
+  static DataTrackSchemaEncoding? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  @$pb.TagNumber(2)
+  DataTrackSchemaEncoding_Value whichValue() => _DataTrackSchemaEncoding_ValueByTag[$_whichOneof(0)]!;
+  @$pb.TagNumber(1)
+  @$pb.TagNumber(2)
+  void clearValue() => $_clearField($_whichOneof(0));
+
+  @$pb.TagNumber(1)
+  DataTrackSchemaEncoding_WellKnownSchemaEncoding get wellKnown => $_getN(0);
+  @$pb.TagNumber(1)
+  set wellKnown(DataTrackSchemaEncoding_WellKnownSchemaEncoding value) => $_setField(1, value);
+  @$pb.TagNumber(1)
+  $core.bool hasWellKnown() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearWellKnown() => $_clearField(1);
+
+  /// Identifier of a custom encoding not covered by the well-known cases.
+  /// This must be non-empty and no longer than 32 characters.
+  @$pb.TagNumber(2)
+  $core.String get custom => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set custom($core.String value) => $_setString(1, value);
+  @$pb.TagNumber(2)
+  $core.bool hasCustom() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearCustom() => $_clearField(2);
+}
+
+/// Identifier for a data track schema.
+///
+/// Schemas with the same name but different encodings are distinct.
+class DataTrackSchemaId extends $pb.GeneratedMessage {
+  factory DataTrackSchemaId({
+    $core.String? name,
+    DataTrackSchemaEncoding? encoding,
+  }) {
+    final result = create();
+    if (name != null) result.name = name;
+    if (encoding != null) result.encoding = encoding;
+    return result;
+  }
+
+  DataTrackSchemaId._();
+
+  factory DataTrackSchemaId.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory DataTrackSchemaId.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DataTrackSchemaId',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'livekit'), createEmptyInstance: create)
+    ..aOS(1, _omitFieldNames ? '' : 'name')
+    ..aOM<DataTrackSchemaEncoding>(2, _omitFieldNames ? '' : 'encoding', subBuilder: DataTrackSchemaEncoding.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DataTrackSchemaId clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DataTrackSchemaId copyWith(void Function(DataTrackSchemaId) updates) =>
+      super.copyWith((message) => updates(message as DataTrackSchemaId)) as DataTrackSchemaId;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DataTrackSchemaId create() => DataTrackSchemaId._();
+  @$core.override
+  DataTrackSchemaId createEmptyInstance() => create();
+  @$core.pragma('dart2js:noInline')
+  static DataTrackSchemaId getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DataTrackSchemaId>(create);
+  static DataTrackSchemaId? _defaultInstance;
+
+  /// This must be non-empty and no longer than 256 characters.
+  @$pb.TagNumber(1)
+  $core.String get name => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set name($core.String value) => $_setString(0, value);
+  @$pb.TagNumber(1)
+  $core.bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearName() => $_clearField(1);
+
+  @$pb.TagNumber(2)
+  DataTrackSchemaEncoding get encoding => $_getN(1);
+  @$pb.TagNumber(2)
+  set encoding(DataTrackSchemaEncoding value) => $_setField(2, value);
+  @$pb.TagNumber(2)
+  $core.bool hasEncoding() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearEncoding() => $_clearField(2);
+  @$pb.TagNumber(2)
+  DataTrackSchemaEncoding ensureEncoding() => $_ensure(1);
 }
 
 class DataTrackExtensionParticipantSid extends $pb.GeneratedMessage {
@@ -1592,6 +1866,153 @@ class DataTrackSubscriptionOptions extends $pb.GeneratedMessage {
   $core.bool hasTargetFps() => $_has(0);
   @$pb.TagNumber(1)
   void clearTargetFps() => $_clearField(1);
+}
+
+enum DataBlobKey_Key { generic, schemaId, notSet }
+
+/// Key used to uniquely identify a data blob for storage and retrieval.
+class DataBlobKey extends $pb.GeneratedMessage {
+  factory DataBlobKey({
+    $core.String? generic,
+    DataTrackSchemaId? schemaId,
+  }) {
+    final result = create();
+    if (generic != null) result.generic = generic;
+    if (schemaId != null) result.schemaId = schemaId;
+    return result;
+  }
+
+  DataBlobKey._();
+
+  factory DataBlobKey.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory DataBlobKey.fromJson($core.String json, [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static const $core.Map<$core.int, DataBlobKey_Key> _DataBlobKey_KeyByTag = {
+    1: DataBlobKey_Key.generic,
+    2: DataBlobKey_Key.schemaId,
+    0: DataBlobKey_Key.notSet
+  };
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DataBlobKey',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'livekit'), createEmptyInstance: create)
+    ..oo(0, [1, 2])
+    ..aOS(1, _omitFieldNames ? '' : 'generic')
+    ..aOM<DataTrackSchemaId>(2, _omitFieldNames ? '' : 'schemaId', subBuilder: DataTrackSchemaId.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DataBlobKey clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DataBlobKey copyWith(void Function(DataBlobKey) updates) =>
+      super.copyWith((message) => updates(message as DataBlobKey)) as DataBlobKey;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DataBlobKey create() => DataBlobKey._();
+  @$core.override
+  DataBlobKey createEmptyInstance() => create();
+  @$core.pragma('dart2js:noInline')
+  static DataBlobKey getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DataBlobKey>(create);
+  static DataBlobKey? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  @$pb.TagNumber(2)
+  DataBlobKey_Key whichKey() => _DataBlobKey_KeyByTag[$_whichOneof(0)]!;
+  @$pb.TagNumber(1)
+  @$pb.TagNumber(2)
+  void clearKey() => $_clearField($_whichOneof(0));
+
+  /// Generic string key, blob contains arbitrary data.
+  @$pb.TagNumber(1)
+  $core.String get generic => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set generic($core.String value) => $_setString(0, value);
+  @$pb.TagNumber(1)
+  $core.bool hasGeneric() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearGeneric() => $_clearField(1);
+
+  /// Data track schema identifier, blob contains schema definition.
+  @$pb.TagNumber(2)
+  DataTrackSchemaId get schemaId => $_getN(1);
+  @$pb.TagNumber(2)
+  set schemaId(DataTrackSchemaId value) => $_setField(2, value);
+  @$pb.TagNumber(2)
+  $core.bool hasSchemaId() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearSchemaId() => $_clearField(2);
+  @$pb.TagNumber(2)
+  DataTrackSchemaId ensureSchemaId() => $_ensure(1);
+}
+
+/// A blob of data stored in a room identified by a unique key.
+class DataBlob extends $pb.GeneratedMessage {
+  factory DataBlob({
+    DataBlobKey? key,
+    $core.List<$core.int>? contents,
+  }) {
+    final result = create();
+    if (key != null) result.key = key;
+    if (contents != null) result.contents = contents;
+    return result;
+  }
+
+  DataBlob._();
+
+  factory DataBlob.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory DataBlob.fromJson($core.String json, [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'DataBlob',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'livekit'), createEmptyInstance: create)
+    ..aOM<DataBlobKey>(1, _omitFieldNames ? '' : 'key', subBuilder: DataBlobKey.create)
+    ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'contents', $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DataBlob clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  DataBlob copyWith(void Function(DataBlob) updates) =>
+      super.copyWith((message) => updates(message as DataBlob)) as DataBlob;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static DataBlob create() => DataBlob._();
+  @$core.override
+  DataBlob createEmptyInstance() => create();
+  @$core.pragma('dart2js:noInline')
+  static DataBlob getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DataBlob>(create);
+  static DataBlob? _defaultInstance;
+
+  /// Unique key the data blob is identified by.
+  @$pb.TagNumber(1)
+  DataBlobKey get key => $_getN(0);
+  @$pb.TagNumber(1)
+  set key(DataBlobKey value) => $_setField(1, value);
+  @$pb.TagNumber(1)
+  $core.bool hasKey() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearKey() => $_clearField(1);
+  @$pb.TagNumber(1)
+  DataBlobKey ensureKey() => $_ensure(0);
+
+  /// Contents of the data blob. This must not exceed 50 KB.
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get contents => $_getN(1);
+  @$pb.TagNumber(2)
+  set contents($core.List<$core.int> value) => $_setBytes(1, value);
+  @$pb.TagNumber(2)
+  $core.bool hasContents() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearContents() => $_clearField(2);
 }
 
 /// provide information about available spatial layers
@@ -5397,6 +5818,8 @@ class DataStream_Header extends $pb.GeneratedMessage {
     $core.Iterable<$core.MapEntry<$core.String, $core.String>>? attributes,
     DataStream_TextHeader? textHeader,
     DataStream_ByteHeader? byteHeader,
+    $core.List<$core.int>? inlineContent,
+    DataStream_CompressionType? compression,
   }) {
     final result = create();
     if (streamId != null) result.streamId = streamId;
@@ -5408,6 +5831,8 @@ class DataStream_Header extends $pb.GeneratedMessage {
     if (attributes != null) result.attributes.addEntries(attributes);
     if (textHeader != null) result.textHeader = textHeader;
     if (byteHeader != null) result.byteHeader = byteHeader;
+    if (inlineContent != null) result.inlineContent = inlineContent;
+    if (compression != null) result.compression = compression;
     return result;
   }
 
@@ -5441,6 +5866,9 @@ class DataStream_Header extends $pb.GeneratedMessage {
         packageName: const $pb.PackageName('livekit'))
     ..aOM<DataStream_TextHeader>(9, _omitFieldNames ? '' : 'textHeader', subBuilder: DataStream_TextHeader.create)
     ..aOM<DataStream_ByteHeader>(10, _omitFieldNames ? '' : 'byteHeader', subBuilder: DataStream_ByteHeader.create)
+    ..a<$core.List<$core.int>>(11, _omitFieldNames ? '' : 'inlineContent', $pb.PbFieldType.OY)
+    ..aE<DataStream_CompressionType>(12, _omitFieldNames ? '' : 'compression',
+        enumValues: DataStream_CompressionType.values)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -5550,6 +5978,25 @@ class DataStream_Header extends $pb.GeneratedMessage {
   void clearByteHeader() => $_clearField(10);
   @$pb.TagNumber(10)
   DataStream_ByteHeader ensureByteHeader() => $_ensure(8);
+
+  /// Optional inline content so that a data stream can be sent as a single packet for short payloads.
+  @$pb.TagNumber(11)
+  $core.List<$core.int> get inlineContent => $_getN(9);
+  @$pb.TagNumber(11)
+  set inlineContent($core.List<$core.int> value) => $_setBytes(9, value);
+  @$pb.TagNumber(11)
+  $core.bool hasInlineContent() => $_has(9);
+  @$pb.TagNumber(11)
+  void clearInlineContent() => $_clearField(11);
+
+  @$pb.TagNumber(12)
+  DataStream_CompressionType get compression => $_getN(10);
+  @$pb.TagNumber(12)
+  set compression(DataStream_CompressionType value) => $_setField(12, value);
+  @$pb.TagNumber(12)
+  $core.bool hasCompression() => $_has(10);
+  @$pb.TagNumber(12)
+  void clearCompression() => $_clearField(12);
 }
 
 class DataStream_Chunk extends $pb.GeneratedMessage {

--- a/lib/src/proto/livekit_models.pbenum.dart
+++ b/lib/src/proto/livekit_models.pbenum.dart
@@ -357,13 +357,15 @@ class PacketTrailerFeature extends $pb.ProtobufEnum {
   static const PacketTrailerFeature PTF_USER_TIMESTAMP =
       PacketTrailerFeature._(0, _omitEnumNames ? '' : 'PTF_USER_TIMESTAMP');
   static const PacketTrailerFeature PTF_FRAME_ID = PacketTrailerFeature._(1, _omitEnumNames ? '' : 'PTF_FRAME_ID');
+  static const PacketTrailerFeature PTF_USER_DATA = PacketTrailerFeature._(2, _omitEnumNames ? '' : 'PTF_USER_DATA');
 
   static const $core.List<PacketTrailerFeature> values = <PacketTrailerFeature>[
     PTF_USER_TIMESTAMP,
     PTF_FRAME_ID,
+    PTF_USER_DATA,
   ];
 
-  static final $core.List<PacketTrailerFeature?> _byValue = $pb.ProtobufEnum.$_initByValueList(values, 1);
+  static final $core.List<PacketTrailerFeature?> _byValue = $pb.ProtobufEnum.$_initByValueList(values, 2);
   static PacketTrailerFeature? valueOf($core.int value) =>
       value < 0 || value >= _byValue.length ? null : _byValue[value];
 
@@ -447,6 +449,8 @@ class ParticipantInfo_KindDetail extends $pb.ProtobufEnum {
       ParticipantInfo_KindDetail._(3, _omitEnumNames ? '' : 'CONNECTOR_TWILIO');
   static const ParticipantInfo_KindDetail BRIDGE_RTSP =
       ParticipantInfo_KindDetail._(4, _omitEnumNames ? '' : 'BRIDGE_RTSP');
+  static const ParticipantInfo_KindDetail SIMULATION =
+      ParticipantInfo_KindDetail._(5, _omitEnumNames ? '' : 'SIMULATION');
 
   static const $core.List<ParticipantInfo_KindDetail> values = <ParticipantInfo_KindDetail>[
     CLOUD_AGENT,
@@ -454,9 +458,10 @@ class ParticipantInfo_KindDetail extends $pb.ProtobufEnum {
     CONNECTOR_WHATSAPP,
     CONNECTOR_TWILIO,
     BRIDGE_RTSP,
+    SIMULATION,
   ];
 
-  static final $core.List<ParticipantInfo_KindDetail?> _byValue = $pb.ProtobufEnum.$_initByValueList(values, 4);
+  static final $core.List<ParticipantInfo_KindDetail?> _byValue = $pb.ProtobufEnum.$_initByValueList(values, 5);
   static ParticipantInfo_KindDetail? valueOf($core.int value) =>
       value < 0 || value >= _byValue.length ? null : _byValue[value];
 
@@ -478,6 +483,121 @@ class Encryption_Type extends $pb.ProtobufEnum {
   static Encryption_Type? valueOf($core.int value) => value < 0 || value >= _byValue.length ? null : _byValue[value];
 
   const Encryption_Type._(super.value, super.name);
+}
+
+/// Well-known encoding for frame payloads.
+///
+/// Mirrors the well-known message encodings from the MCAP spec:
+/// https://mcap.dev/spec/registry#message-encodings
+class DataTrackFrameEncoding_WellKnownFrameEncoding extends $pb.ProtobufEnum {
+  static const DataTrackFrameEncoding_WellKnownFrameEncoding WELL_KNOWN_FRAME_ENCODING_UNSPECIFIED =
+      DataTrackFrameEncoding_WellKnownFrameEncoding._(0, _omitEnumNames ? '' : 'WELL_KNOWN_FRAME_ENCODING_UNSPECIFIED');
+
+  /// ROS 1: must be described by `ROS1_MSG` schema encoding.
+  static const DataTrackFrameEncoding_WellKnownFrameEncoding WELL_KNOWN_FRAME_ENCODING_ROS1 =
+      DataTrackFrameEncoding_WellKnownFrameEncoding._(1, _omitEnumNames ? '' : 'WELL_KNOWN_FRAME_ENCODING_ROS1');
+
+  /// CDR: must be described by `ROS2_MSG`, `ROS2_IDL`, or `OMG_IDL` schema encoding.
+  static const DataTrackFrameEncoding_WellKnownFrameEncoding WELL_KNOWN_FRAME_ENCODING_CDR =
+      DataTrackFrameEncoding_WellKnownFrameEncoding._(2, _omitEnumNames ? '' : 'WELL_KNOWN_FRAME_ENCODING_CDR');
+
+  /// Protocol Buffer: must be described by `PROTOBUF` schema encoding.
+  static const DataTrackFrameEncoding_WellKnownFrameEncoding WELL_KNOWN_FRAME_ENCODING_PROTOBUF =
+      DataTrackFrameEncoding_WellKnownFrameEncoding._(3, _omitEnumNames ? '' : 'WELL_KNOWN_FRAME_ENCODING_PROTOBUF');
+
+  /// FlatBuffer: must be described by `FLATBUFFER` schema encoding.
+  static const DataTrackFrameEncoding_WellKnownFrameEncoding WELL_KNOWN_FRAME_ENCODING_FLATBUFFER =
+      DataTrackFrameEncoding_WellKnownFrameEncoding._(4, _omitEnumNames ? '' : 'WELL_KNOWN_FRAME_ENCODING_FLATBUFFER');
+
+  /// CBOR: self-describing.
+  static const DataTrackFrameEncoding_WellKnownFrameEncoding WELL_KNOWN_FRAME_ENCODING_CBOR =
+      DataTrackFrameEncoding_WellKnownFrameEncoding._(5, _omitEnumNames ? '' : 'WELL_KNOWN_FRAME_ENCODING_CBOR');
+
+  /// MessagePack: self-describing.
+  static const DataTrackFrameEncoding_WellKnownFrameEncoding WELL_KNOWN_FRAME_ENCODING_MSGPACK =
+      DataTrackFrameEncoding_WellKnownFrameEncoding._(6, _omitEnumNames ? '' : 'WELL_KNOWN_FRAME_ENCODING_MSGPACK');
+
+  /// JSON: self-describing or described by `JSON_SCHEMA` schema encoding.
+  static const DataTrackFrameEncoding_WellKnownFrameEncoding WELL_KNOWN_FRAME_ENCODING_JSON =
+      DataTrackFrameEncoding_WellKnownFrameEncoding._(7, _omitEnumNames ? '' : 'WELL_KNOWN_FRAME_ENCODING_JSON');
+
+  static const $core.List<DataTrackFrameEncoding_WellKnownFrameEncoding> values =
+      <DataTrackFrameEncoding_WellKnownFrameEncoding>[
+    WELL_KNOWN_FRAME_ENCODING_UNSPECIFIED,
+    WELL_KNOWN_FRAME_ENCODING_ROS1,
+    WELL_KNOWN_FRAME_ENCODING_CDR,
+    WELL_KNOWN_FRAME_ENCODING_PROTOBUF,
+    WELL_KNOWN_FRAME_ENCODING_FLATBUFFER,
+    WELL_KNOWN_FRAME_ENCODING_CBOR,
+    WELL_KNOWN_FRAME_ENCODING_MSGPACK,
+    WELL_KNOWN_FRAME_ENCODING_JSON,
+  ];
+
+  static final $core.List<DataTrackFrameEncoding_WellKnownFrameEncoding?> _byValue =
+      $pb.ProtobufEnum.$_initByValueList(values, 7);
+  static DataTrackFrameEncoding_WellKnownFrameEncoding? valueOf($core.int value) =>
+      value < 0 || value >= _byValue.length ? null : _byValue[value];
+
+  const DataTrackFrameEncoding_WellKnownFrameEncoding._(super.value, super.name);
+}
+
+/// Well-known encoding for schema definition.
+///
+/// Mirrors the well-known schema encodings from the MCAP spec:
+/// https://mcap.dev/spec/registry#schema-encodings
+class DataTrackSchemaEncoding_WellKnownSchemaEncoding extends $pb.ProtobufEnum {
+  static const DataTrackSchemaEncoding_WellKnownSchemaEncoding WELL_KNOWN_SCHEMA_ENCODING_UNSPECIFIED =
+      DataTrackSchemaEncoding_WellKnownSchemaEncoding._(
+          0, _omitEnumNames ? '' : 'WELL_KNOWN_SCHEMA_ENCODING_UNSPECIFIED');
+
+  /// Protocol Buffer IDL: describes `PROTOBUF` frame encoding.
+  static const DataTrackSchemaEncoding_WellKnownSchemaEncoding WELL_KNOWN_SCHEMA_ENCODING_PROTOBUF =
+      DataTrackSchemaEncoding_WellKnownSchemaEncoding._(1, _omitEnumNames ? '' : 'WELL_KNOWN_SCHEMA_ENCODING_PROTOBUF');
+
+  /// FlatBuffer IDL: describes `FLATBUFFER` frame encoding.
+  static const DataTrackSchemaEncoding_WellKnownSchemaEncoding WELL_KNOWN_SCHEMA_ENCODING_FLATBUFFER =
+      DataTrackSchemaEncoding_WellKnownSchemaEncoding._(
+          2, _omitEnumNames ? '' : 'WELL_KNOWN_SCHEMA_ENCODING_FLATBUFFER');
+
+  /// ROS 1 Message: describes `ROS1` frame encoding.
+  static const DataTrackSchemaEncoding_WellKnownSchemaEncoding WELL_KNOWN_SCHEMA_ENCODING_ROS1_MSG =
+      DataTrackSchemaEncoding_WellKnownSchemaEncoding._(3, _omitEnumNames ? '' : 'WELL_KNOWN_SCHEMA_ENCODING_ROS1_MSG');
+
+  /// ROS 2 Message: describes `CDR` frame encoding.
+  static const DataTrackSchemaEncoding_WellKnownSchemaEncoding WELL_KNOWN_SCHEMA_ENCODING_ROS2_MSG =
+      DataTrackSchemaEncoding_WellKnownSchemaEncoding._(4, _omitEnumNames ? '' : 'WELL_KNOWN_SCHEMA_ENCODING_ROS2_MSG');
+
+  /// ROS 2 IDL: describes `CDR` frame encoding.
+  static const DataTrackSchemaEncoding_WellKnownSchemaEncoding WELL_KNOWN_SCHEMA_ENCODING_ROS2_IDL =
+      DataTrackSchemaEncoding_WellKnownSchemaEncoding._(5, _omitEnumNames ? '' : 'WELL_KNOWN_SCHEMA_ENCODING_ROS2_IDL');
+
+  /// OMG IDL: describes `CDR` frame encoding.
+  static const DataTrackSchemaEncoding_WellKnownSchemaEncoding WELL_KNOWN_SCHEMA_ENCODING_OMG_IDL =
+      DataTrackSchemaEncoding_WellKnownSchemaEncoding._(6, _omitEnumNames ? '' : 'WELL_KNOWN_SCHEMA_ENCODING_OMG_IDL');
+
+  /// JSON Schema: describes `JSON` frame encoding.
+  static const DataTrackSchemaEncoding_WellKnownSchemaEncoding WELL_KNOWN_SCHEMA_ENCODING_JSON_SCHEMA =
+      DataTrackSchemaEncoding_WellKnownSchemaEncoding._(
+          7, _omitEnumNames ? '' : 'WELL_KNOWN_SCHEMA_ENCODING_JSON_SCHEMA');
+
+  static const $core.List<DataTrackSchemaEncoding_WellKnownSchemaEncoding> values =
+      <DataTrackSchemaEncoding_WellKnownSchemaEncoding>[
+    WELL_KNOWN_SCHEMA_ENCODING_UNSPECIFIED,
+    WELL_KNOWN_SCHEMA_ENCODING_PROTOBUF,
+    WELL_KNOWN_SCHEMA_ENCODING_FLATBUFFER,
+    WELL_KNOWN_SCHEMA_ENCODING_ROS1_MSG,
+    WELL_KNOWN_SCHEMA_ENCODING_ROS2_MSG,
+    WELL_KNOWN_SCHEMA_ENCODING_ROS2_IDL,
+    WELL_KNOWN_SCHEMA_ENCODING_OMG_IDL,
+    WELL_KNOWN_SCHEMA_ENCODING_JSON_SCHEMA,
+  ];
+
+  static final $core.List<DataTrackSchemaEncoding_WellKnownSchemaEncoding?> _byValue =
+      $pb.ProtobufEnum.$_initByValueList(values, 7);
+  static DataTrackSchemaEncoding_WellKnownSchemaEncoding? valueOf($core.int value) =>
+      value < 0 || value >= _byValue.length ? null : _byValue[value];
+
+  const DataTrackSchemaEncoding_WellKnownSchemaEncoding._(super.value, super.name);
 }
 
 class VideoLayer_Mode extends $pb.ProtobufEnum {
@@ -581,13 +701,16 @@ class ClientInfo_Capability extends $pb.ProtobufEnum {
   static const ClientInfo_Capability CAP_UNUSED = ClientInfo_Capability._(0, _omitEnumNames ? '' : 'CAP_UNUSED');
   static const ClientInfo_Capability CAP_PACKET_TRAILER =
       ClientInfo_Capability._(1, _omitEnumNames ? '' : 'CAP_PACKET_TRAILER');
+  static const ClientInfo_Capability CAP_COMPRESSION_DEFLATE_RAW =
+      ClientInfo_Capability._(2, _omitEnumNames ? '' : 'CAP_COMPRESSION_DEFLATE_RAW');
 
   static const $core.List<ClientInfo_Capability> values = <ClientInfo_Capability>[
     CAP_UNUSED,
     CAP_PACKET_TRAILER,
+    CAP_COMPRESSION_DEFLATE_RAW,
   ];
 
-  static final $core.List<ClientInfo_Capability?> _byValue = $pb.ProtobufEnum.$_initByValueList(values, 1);
+  static final $core.List<ClientInfo_Capability?> _byValue = $pb.ProtobufEnum.$_initByValueList(values, 2);
   static ClientInfo_Capability? valueOf($core.int value) =>
       value < 0 || value >= _byValue.length ? null : _byValue[value];
 
@@ -613,6 +736,27 @@ class DataStream_OperationType extends $pb.ProtobufEnum {
       value < 0 || value >= _byValue.length ? null : _byValue[value];
 
   const DataStream_OperationType._(super.value, super.name);
+}
+
+/// The compression type of the whole data stream
+///
+/// This will only get populated when send to participants with a
+/// client protocol >= 2 which advertise a client capability of CAP_COMPRESSION_DEFLATE_RAW
+class DataStream_CompressionType extends $pb.ProtobufEnum {
+  static const DataStream_CompressionType NONE = DataStream_CompressionType._(0, _omitEnumNames ? '' : 'NONE');
+  static const DataStream_CompressionType DEFLATE_RAW =
+      DataStream_CompressionType._(1, _omitEnumNames ? '' : 'DEFLATE_RAW');
+
+  static const $core.List<DataStream_CompressionType> values = <DataStream_CompressionType>[
+    NONE,
+    DEFLATE_RAW,
+  ];
+
+  static final $core.List<DataStream_CompressionType?> _byValue = $pb.ProtobufEnum.$_initByValueList(values, 1);
+  static DataStream_CompressionType? valueOf($core.int value) =>
+      value < 0 || value >= _byValue.length ? null : _byValue[value];
+
+  const DataStream_CompressionType._(super.value, super.name);
 }
 
 const $core.bool _omitEnumNames = $core.bool.fromEnvironment('protobuf.omit_enum_names');

--- a/lib/src/proto/livekit_models.pbjson.dart
+++ b/lib/src/proto/livekit_models.pbjson.dart
@@ -261,13 +261,14 @@ const PacketTrailerFeature$json = {
   '2': [
     {'1': 'PTF_USER_TIMESTAMP', '2': 0},
     {'1': 'PTF_FRAME_ID', '2': 1},
+    {'1': 'PTF_USER_DATA', '2': 2},
   ],
 };
 
 /// Descriptor for `PacketTrailerFeature`. Decode as a `google.protobuf.EnumDescriptorProto`.
 final $typed_data.Uint8List packetTrailerFeatureDescriptor =
     $convert.base64Decode('ChRQYWNrZXRUcmFpbGVyRmVhdHVyZRIWChJQVEZfVVNFUl9USU1FU1RBTVAQABIQCgxQVEZfRl'
-        'JBTUVfSUQQAQ==');
+        'JBTUVfSUQQARIRCg1QVEZfVVNFUl9EQVRBEAI=');
 
 @$core.Deprecated('Use paginationDescriptor instead')
 const Pagination$json = {
@@ -340,8 +341,8 @@ final $typed_data.Uint8List roomDescriptor =
         '50cxIjCg1jcmVhdGlvbl90aW1lGAUgASgDUgxjcmVhdGlvblRpbWUSKAoQY3JlYXRpb25fdGlt'
         'ZV9tcxgPIAEoA1IOY3JlYXRpb25UaW1lTXMSIwoNdHVybl9wYXNzd29yZBgGIAEoCVIMdHVybl'
         'Bhc3N3b3JkEjUKDmVuYWJsZWRfY29kZWNzGAcgAygLMg4ubGl2ZWtpdC5Db2RlY1INZW5hYmxl'
-        'ZENvZGVjcxJACghtZXRhZGF0YRgIIAEoCUIkqFABslAePHJlZGFjdGVkICh7eyAuU2l6ZSB9fS'
-        'BieXRlcyk+UghtZXRhZGF0YRIpChBudW1fcGFydGljaXBhbnRzGAkgASgNUg9udW1QYXJ0aWNp'
+        'ZENvZGVjcxJACghtZXRhZGF0YRgIIAEoCUIkslAePHJlZGFjdGVkICh7eyAuU2l6ZSB9fSBieX'
+        'Rlcyk+wFABUghtZXRhZGF0YRIpChBudW1fcGFydGljaXBhbnRzGAkgASgNUg9udW1QYXJ0aWNp'
         'cGFudHMSJQoObnVtX3B1Ymxpc2hlcnMYCyABKA1SDW51bVB1Ymxpc2hlcnMSKQoQYWN0aXZlX3'
         'JlY29yZGluZxgKIAEoCFIPYWN0aXZlUmVjb3JkaW5nEi8KB3ZlcnNpb24YDSABKAsyFS5saXZl'
         'a2l0LlRpbWVkVmVyc2lvblIHdmVyc2lvbg==');
@@ -447,6 +448,7 @@ const ParticipantInfo$json = {
     {'1': 'kind_details', '3': 18, '4': 3, '5': 14, '6': '.livekit.ParticipantInfo.KindDetail', '10': 'kindDetails'},
     {'1': 'data_tracks', '3': 19, '4': 3, '5': 11, '6': '.livekit.DataTrackInfo', '10': 'dataTracks'},
     {'1': 'client_protocol', '3': 20, '4': 1, '5': 5, '10': 'clientProtocol'},
+    {'1': 'capabilities', '3': 21, '4': 3, '5': 14, '6': '.livekit.ClientInfo.Capability', '10': 'capabilities'},
   ],
   '3': [ParticipantInfo_AttributesEntry$json],
   '4': [ParticipantInfo_State$json, ParticipantInfo_Kind$json, ParticipantInfo_KindDetail$json],
@@ -496,6 +498,7 @@ const ParticipantInfo_KindDetail$json = {
     {'1': 'CONNECTOR_WHATSAPP', '2': 2},
     {'1': 'CONNECTOR_TWILIO', '2': 3},
     {'1': 'BRIDGE_RTSP', '2': 4},
+    {'1': 'SIMULATION', '2': 5},
   ],
 };
 
@@ -504,25 +507,27 @@ final $typed_data.Uint8List participantInfoDescriptor =
     $convert.base64Decode('Cg9QYXJ0aWNpcGFudEluZm8SEAoDc2lkGAEgASgJUgNzaWQSGgoIaWRlbnRpdHkYAiABKAlSCG'
         'lkZW50aXR5EjQKBXN0YXRlGAMgASgOMh4ubGl2ZWtpdC5QYXJ0aWNpcGFudEluZm8uU3RhdGVS'
         'BXN0YXRlEioKBnRyYWNrcxgEIAMoCzISLmxpdmVraXQuVHJhY2tJbmZvUgZ0cmFja3MSQAoIbW'
-        'V0YWRhdGEYBSABKAlCJKhQAbJQHjxyZWRhY3RlZCAoe3sgLlNpemUgfX0gYnl0ZXMpPlIIbWV0'
+        'V0YWRhdGEYBSABKAlCJLJQHjxyZWRhY3RlZCAoe3sgLlNpemUgfX0gYnl0ZXMpPsBQAVIIbWV0'
         'YWRhdGESGwoJam9pbmVkX2F0GAYgASgDUghqb2luZWRBdBIgCgxqb2luZWRfYXRfbXMYESABKA'
-        'NSCmpvaW5lZEF0TXMSFwoEbmFtZRgJIAEoCUIDqFABUgRuYW1lEhgKB3ZlcnNpb24YCiABKA1S'
+        'NSCmpvaW5lZEF0TXMSFwoEbmFtZRgJIAEoCUIDwFABUgRuYW1lEhgKB3ZlcnNpb24YCiABKA1S'
         'B3ZlcnNpb24SPgoKcGVybWlzc2lvbhgLIAEoCzIeLmxpdmVraXQuUGFydGljaXBhbnRQZXJtaX'
         'NzaW9uUgpwZXJtaXNzaW9uEhYKBnJlZ2lvbhgMIAEoCVIGcmVnaW9uEiEKDGlzX3B1Ymxpc2hl'
         'chgNIAEoCFILaXNQdWJsaXNoZXISMQoEa2luZBgOIAEoDjIdLmxpdmVraXQuUGFydGljaXBhbn'
         'RJbmZvLktpbmRSBGtpbmQSbgoKYXR0cmlidXRlcxgPIAMoCzIoLmxpdmVraXQuUGFydGljaXBh'
-        'bnRJbmZvLkF0dHJpYnV0ZXNFbnRyeUIkqFABslAePHJlZGFjdGVkICh7eyAuU2l6ZSB9fSBieX'
-        'Rlcyk+UgphdHRyaWJ1dGVzEkYKEWRpc2Nvbm5lY3RfcmVhc29uGBAgASgOMhkubGl2ZWtpdC5E'
+        'bnRJbmZvLkF0dHJpYnV0ZXNFbnRyeUIkslAePHJlZGFjdGVkICh7eyAuU2l6ZSB9fSBieXRlcy'
+        'k+wFABUgphdHRyaWJ1dGVzEkYKEWRpc2Nvbm5lY3RfcmVhc29uGBAgASgOMhkubGl2ZWtpdC5E'
         'aXNjb25uZWN0UmVhc29uUhBkaXNjb25uZWN0UmVhc29uEkYKDGtpbmRfZGV0YWlscxgSIAMoDj'
         'IjLmxpdmVraXQuUGFydGljaXBhbnRJbmZvLktpbmREZXRhaWxSC2tpbmREZXRhaWxzEjcKC2Rh'
         'dGFfdHJhY2tzGBMgAygLMhYubGl2ZWtpdC5EYXRhVHJhY2tJbmZvUgpkYXRhVHJhY2tzEicKD2'
-        'NsaWVudF9wcm90b2NvbBgUIAEoBVIOY2xpZW50UHJvdG9jb2waPQoPQXR0cmlidXRlc0VudHJ5'
-        'EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAEiPgoFU3RhdGUSCw'
-        'oHSk9JTklORxAAEgoKBkpPSU5FRBABEgoKBkFDVElWRRACEhAKDERJU0NPTk5FQ1RFRBADIlwK'
-        'BEtpbmQSDAoIU1RBTkRBUkQQABILCgdJTkdSRVNTEAESCgoGRUdSRVNTEAISBwoDU0lQEAMSCQ'
-        'oFQUdFTlQQBBINCglDT05ORUNUT1IQBxIKCgZCUklER0UQCCJrCgpLaW5kRGV0YWlsEg8KC0NM'
-        'T1VEX0FHRU5UEAASDQoJRk9SV0FSREVEEAESFgoSQ09OTkVDVE9SX1dIQVRTQVBQEAISFAoQQ0'
-        '9OTkVDVE9SX1RXSUxJTxADEg8KC0JSSURHRV9SVFNQEAQ=');
+        'NsaWVudF9wcm90b2NvbBgUIAEoBVIOY2xpZW50UHJvdG9jb2wSQgoMY2FwYWJpbGl0aWVzGBUg'
+        'AygOMh4ubGl2ZWtpdC5DbGllbnRJbmZvLkNhcGFiaWxpdHlSDGNhcGFiaWxpdGllcxo9Cg9BdH'
+        'RyaWJ1dGVzRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4'
+        'ASI+CgVTdGF0ZRILCgdKT0lOSU5HEAASCgoGSk9JTkVEEAESCgoGQUNUSVZFEAISEAoMRElTQ0'
+        '9OTkVDVEVEEAMiXAoES2luZBIMCghTVEFOREFSRBAAEgsKB0lOR1JFU1MQARIKCgZFR1JFU1MQ'
+        'AhIHCgNTSVAQAxIJCgVBR0VOVBAEEg0KCUNPTk5FQ1RPUhAHEgoKBkJSSURHRRAIInsKCktpbm'
+        'REZXRhaWwSDwoLQ0xPVURfQUdFTlQQABINCglGT1JXQVJERUQQARIWChJDT05ORUNUT1JfV0hB'
+        'VFNBUFAQAhIUChBDT05ORUNUT1JfVFdJTElPEAMSDwoLQlJJREdFX1JUU1AQBBIOCgpTSU1VTE'
+        'FUSU9OEAU=');
 
 @$core.Deprecated('Use encryptionDescriptor instead')
 const Encryption$json = {
@@ -639,7 +644,7 @@ const TrackInfo$json = {
 /// Descriptor for `TrackInfo`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List trackInfoDescriptor =
     $convert.base64Decode('CglUcmFja0luZm8SEAoDc2lkGAEgASgJUgNzaWQSJgoEdHlwZRgCIAEoDjISLmxpdmVraXQuVH'
-        'JhY2tUeXBlUgR0eXBlEhcKBG5hbWUYAyABKAlCA6hQAVIEbmFtZRIUCgVtdXRlZBgEIAEoCFIF'
+        'JhY2tUeXBlUgR0eXBlEhcKBG5hbWUYAyABKAlCA8BQAVIEbmFtZRIUCgVtdXRlZBgEIAEoCFIF'
         'bXV0ZWQSFAoFd2lkdGgYBSABKA1SBXdpZHRoEhYKBmhlaWdodBgGIAEoDVIGaGVpZ2h0EiAKCX'
         'NpbXVsY2FzdBgHIAEoCEICGAFSCXNpbXVsY2FzdBIjCgtkaXNhYmxlX2R0eBgIIAEoCEICGAFS'
         'CmRpc2FibGVEdHgSLAoGc291cmNlGAkgASgOMhQubGl2ZWtpdC5UcmFja1NvdXJjZVIGc291cm'
@@ -663,6 +668,21 @@ const DataTrackInfo$json = {
     {'1': 'sid', '3': 2, '4': 1, '5': 9, '10': 'sid'},
     {'1': 'name', '3': 3, '4': 1, '5': 9, '10': 'name'},
     {'1': 'encryption', '3': 4, '4': 1, '5': 14, '6': '.livekit.Encryption.Type', '10': 'encryption'},
+    {
+      '1': 'frame_encoding',
+      '3': 5,
+      '4': 1,
+      '5': 11,
+      '6': '.livekit.DataTrackFrameEncoding',
+      '9': 0,
+      '10': 'frameEncoding',
+      '17': true
+    },
+    {'1': 'schema', '3': 6, '4': 1, '5': 11, '6': '.livekit.DataTrackSchemaId', '9': 1, '10': 'schema', '17': true},
+  ],
+  '8': [
+    {'1': '_frame_encoding'},
+    {'1': '_schema'},
   ],
 };
 
@@ -670,7 +690,121 @@ const DataTrackInfo$json = {
 final $typed_data.Uint8List dataTrackInfoDescriptor =
     $convert.base64Decode('Cg1EYXRhVHJhY2tJbmZvEh0KCnB1Yl9oYW5kbGUYASABKA1SCXB1YkhhbmRsZRIQCgNzaWQYAi'
         'ABKAlSA3NpZBISCgRuYW1lGAMgASgJUgRuYW1lEjgKCmVuY3J5cHRpb24YBCABKA4yGC5saXZl'
-        'a2l0LkVuY3J5cHRpb24uVHlwZVIKZW5jcnlwdGlvbg==');
+        'a2l0LkVuY3J5cHRpb24uVHlwZVIKZW5jcnlwdGlvbhJLCg5mcmFtZV9lbmNvZGluZxgFIAEoCz'
+        'IfLmxpdmVraXQuRGF0YVRyYWNrRnJhbWVFbmNvZGluZ0gAUg1mcmFtZUVuY29kaW5niAEBEjcK'
+        'BnNjaGVtYRgGIAEoCzIaLmxpdmVraXQuRGF0YVRyYWNrU2NoZW1hSWRIAVIGc2NoZW1hiAEBQh'
+        'EKD19mcmFtZV9lbmNvZGluZ0IJCgdfc2NoZW1h');
+
+@$core.Deprecated('Use dataTrackFrameEncodingDescriptor instead')
+const DataTrackFrameEncoding$json = {
+  '1': 'DataTrackFrameEncoding',
+  '2': [
+    {
+      '1': 'well_known',
+      '3': 1,
+      '4': 1,
+      '5': 14,
+      '6': '.livekit.DataTrackFrameEncoding.WellKnownFrameEncoding',
+      '9': 0,
+      '10': 'wellKnown'
+    },
+    {'1': 'custom', '3': 2, '4': 1, '5': 9, '9': 0, '10': 'custom'},
+  ],
+  '4': [DataTrackFrameEncoding_WellKnownFrameEncoding$json],
+  '8': [
+    {'1': 'value'},
+  ],
+};
+
+@$core.Deprecated('Use dataTrackFrameEncodingDescriptor instead')
+const DataTrackFrameEncoding_WellKnownFrameEncoding$json = {
+  '1': 'WellKnownFrameEncoding',
+  '2': [
+    {'1': 'WELL_KNOWN_FRAME_ENCODING_UNSPECIFIED', '2': 0},
+    {'1': 'WELL_KNOWN_FRAME_ENCODING_ROS1', '2': 1},
+    {'1': 'WELL_KNOWN_FRAME_ENCODING_CDR', '2': 2},
+    {'1': 'WELL_KNOWN_FRAME_ENCODING_PROTOBUF', '2': 3},
+    {'1': 'WELL_KNOWN_FRAME_ENCODING_FLATBUFFER', '2': 4},
+    {'1': 'WELL_KNOWN_FRAME_ENCODING_CBOR', '2': 5},
+    {'1': 'WELL_KNOWN_FRAME_ENCODING_MSGPACK', '2': 6},
+    {'1': 'WELL_KNOWN_FRAME_ENCODING_JSON', '2': 7},
+  ],
+};
+
+/// Descriptor for `DataTrackFrameEncoding`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List dataTrackFrameEncodingDescriptor =
+    $convert.base64Decode('ChZEYXRhVHJhY2tGcmFtZUVuY29kaW5nElcKCndlbGxfa25vd24YASABKA4yNi5saXZla2l0Lk'
+        'RhdGFUcmFja0ZyYW1lRW5jb2RpbmcuV2VsbEtub3duRnJhbWVFbmNvZGluZ0gAUgl3ZWxsS25v'
+        'd24SGAoGY3VzdG9tGAIgASgJSABSBmN1c3RvbSLLAgoWV2VsbEtub3duRnJhbWVFbmNvZGluZx'
+        'IpCiVXRUxMX0tOT1dOX0ZSQU1FX0VOQ09ESU5HX1VOU1BFQ0lGSUVEEAASIgoeV0VMTF9LTk9X'
+        'Tl9GUkFNRV9FTkNPRElOR19ST1MxEAESIQodV0VMTF9LTk9XTl9GUkFNRV9FTkNPRElOR19DRF'
+        'IQAhImCiJXRUxMX0tOT1dOX0ZSQU1FX0VOQ09ESU5HX1BST1RPQlVGEAMSKAokV0VMTF9LTk9X'
+        'Tl9GUkFNRV9FTkNPRElOR19GTEFUQlVGRkVSEAQSIgoeV0VMTF9LTk9XTl9GUkFNRV9FTkNPRE'
+        'lOR19DQk9SEAUSJQohV0VMTF9LTk9XTl9GUkFNRV9FTkNPRElOR19NU0dQQUNLEAYSIgoeV0VM'
+        'TF9LTk9XTl9GUkFNRV9FTkNPRElOR19KU09OEAdCBwoFdmFsdWU=');
+
+@$core.Deprecated('Use dataTrackSchemaEncodingDescriptor instead')
+const DataTrackSchemaEncoding$json = {
+  '1': 'DataTrackSchemaEncoding',
+  '2': [
+    {
+      '1': 'well_known',
+      '3': 1,
+      '4': 1,
+      '5': 14,
+      '6': '.livekit.DataTrackSchemaEncoding.WellKnownSchemaEncoding',
+      '9': 0,
+      '10': 'wellKnown'
+    },
+    {'1': 'custom', '3': 2, '4': 1, '5': 9, '9': 0, '10': 'custom'},
+  ],
+  '4': [DataTrackSchemaEncoding_WellKnownSchemaEncoding$json],
+  '8': [
+    {'1': 'value'},
+  ],
+};
+
+@$core.Deprecated('Use dataTrackSchemaEncodingDescriptor instead')
+const DataTrackSchemaEncoding_WellKnownSchemaEncoding$json = {
+  '1': 'WellKnownSchemaEncoding',
+  '2': [
+    {'1': 'WELL_KNOWN_SCHEMA_ENCODING_UNSPECIFIED', '2': 0},
+    {'1': 'WELL_KNOWN_SCHEMA_ENCODING_PROTOBUF', '2': 1},
+    {'1': 'WELL_KNOWN_SCHEMA_ENCODING_FLATBUFFER', '2': 2},
+    {'1': 'WELL_KNOWN_SCHEMA_ENCODING_ROS1_MSG', '2': 3},
+    {'1': 'WELL_KNOWN_SCHEMA_ENCODING_ROS2_MSG', '2': 4},
+    {'1': 'WELL_KNOWN_SCHEMA_ENCODING_ROS2_IDL', '2': 5},
+    {'1': 'WELL_KNOWN_SCHEMA_ENCODING_OMG_IDL', '2': 6},
+    {'1': 'WELL_KNOWN_SCHEMA_ENCODING_JSON_SCHEMA', '2': 7},
+  ],
+};
+
+/// Descriptor for `DataTrackSchemaEncoding`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List dataTrackSchemaEncodingDescriptor =
+    $convert.base64Decode('ChdEYXRhVHJhY2tTY2hlbWFFbmNvZGluZxJZCgp3ZWxsX2tub3duGAEgASgOMjgubGl2ZWtpdC'
+        '5EYXRhVHJhY2tTY2hlbWFFbmNvZGluZy5XZWxsS25vd25TY2hlbWFFbmNvZGluZ0gAUgl3ZWxs'
+        'S25vd24SGAoGY3VzdG9tGAIgASgJSABSBmN1c3RvbSLoAgoXV2VsbEtub3duU2NoZW1hRW5jb2'
+        'RpbmcSKgomV0VMTF9LTk9XTl9TQ0hFTUFfRU5DT0RJTkdfVU5TUEVDSUZJRUQQABInCiNXRUxM'
+        'X0tOT1dOX1NDSEVNQV9FTkNPRElOR19QUk9UT0JVRhABEikKJVdFTExfS05PV05fU0NIRU1BX0'
+        'VOQ09ESU5HX0ZMQVRCVUZGRVIQAhInCiNXRUxMX0tOT1dOX1NDSEVNQV9FTkNPRElOR19ST1Mx'
+        'X01TRxADEicKI1dFTExfS05PV05fU0NIRU1BX0VOQ09ESU5HX1JPUzJfTVNHEAQSJwojV0VMTF'
+        '9LTk9XTl9TQ0hFTUFfRU5DT0RJTkdfUk9TMl9JREwQBRImCiJXRUxMX0tOT1dOX1NDSEVNQV9F'
+        'TkNPRElOR19PTUdfSURMEAYSKgomV0VMTF9LTk9XTl9TQ0hFTUFfRU5DT0RJTkdfSlNPTl9TQ0'
+        'hFTUEQB0IHCgV2YWx1ZQ==');
+
+@$core.Deprecated('Use dataTrackSchemaIdDescriptor instead')
+const DataTrackSchemaId$json = {
+  '1': 'DataTrackSchemaId',
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'encoding', '3': 2, '4': 1, '5': 11, '6': '.livekit.DataTrackSchemaEncoding', '10': 'encoding'},
+  ],
+};
+
+/// Descriptor for `DataTrackSchemaId`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List dataTrackSchemaIdDescriptor =
+    $convert.base64Decode('ChFEYXRhVHJhY2tTY2hlbWFJZBISCgRuYW1lGAEgASgJUgRuYW1lEjwKCGVuY29kaW5nGAIgAS'
+        'gLMiAubGl2ZWtpdC5EYXRhVHJhY2tTY2hlbWFFbmNvZGluZ1IIZW5jb2Rpbmc=');
 
 @$core.Deprecated('Use dataTrackExtensionParticipantSidDescriptor instead')
 const DataTrackExtensionParticipantSid$json = {
@@ -702,6 +836,39 @@ const DataTrackSubscriptionOptions$json = {
 final $typed_data.Uint8List dataTrackSubscriptionOptionsDescriptor =
     $convert.base64Decode('ChxEYXRhVHJhY2tTdWJzY3JpcHRpb25PcHRpb25zEiIKCnRhcmdldF9mcHMYASABKA1IAFIJdG'
         'FyZ2V0RnBziAEBQg0KC190YXJnZXRfZnBz');
+
+@$core.Deprecated('Use dataBlobKeyDescriptor instead')
+const DataBlobKey$json = {
+  '1': 'DataBlobKey',
+  '2': [
+    {'1': 'generic', '3': 1, '4': 1, '5': 9, '9': 0, '10': 'generic'},
+    {'1': 'schema_id', '3': 2, '4': 1, '5': 11, '6': '.livekit.DataTrackSchemaId', '8': {}, '9': 0, '10': 'schemaId'},
+  ],
+  '8': [
+    {'1': 'key'},
+  ],
+};
+
+/// Descriptor for `DataBlobKey`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List dataBlobKeyDescriptor =
+    $convert.base64Decode('CgtEYXRhQmxvYktleRIaCgdnZW5lcmljGAEgASgJSABSB2dlbmVyaWMSRgoJc2NoZW1hX2lkGA'
+        'IgASgLMhoubGl2ZWtpdC5EYXRhVHJhY2tTY2hlbWFJZEILulAIc2NoZW1hSURIAFIIc2NoZW1h'
+        'SWRCBQoDa2V5');
+
+@$core.Deprecated('Use dataBlobDescriptor instead')
+const DataBlob$json = {
+  '1': 'DataBlob',
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 11, '6': '.livekit.DataBlobKey', '10': 'key'},
+    {'1': 'contents', '3': 2, '4': 1, '5': 12, '8': {}, '10': 'contents'},
+  ],
+};
+
+/// Descriptor for `DataBlob`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List dataBlobDescriptor =
+    $convert.base64Decode('CghEYXRhQmxvYhImCgNrZXkYASABKAsyFC5saXZla2l0LkRhdGFCbG9iS2V5UgNrZXkSQAoIY2'
+        '9udGVudHMYAiABKAxCJLJQHjxyZWRhY3RlZCAoe3sgLlNpemUgfX0gYnl0ZXMpPsBQAVIIY29u'
+        'dGVudHM=');
 
 @$core.Deprecated('Use videoLayerDescriptor instead')
 const VideoLayer$json = {
@@ -1210,6 +1377,7 @@ const ClientInfo_Capability$json = {
   '2': [
     {'1': 'CAP_UNUSED', '2': 0},
     {'1': 'CAP_PACKET_TRAILER', '2': 1},
+    {'1': 'CAP_COMPRESSION_DEFLATE_RAW', '2': 2},
   ],
 };
 
@@ -1226,8 +1394,8 @@ final $typed_data.Uint8List clientInfoDescriptor =
         'bGl0aWVzIrMBCgNTREsSCwoHVU5LTk9XThAAEgYKAkpTEAESCQoFU1dJRlQQAhILCgdBTkRST0'
         'lEEAMSCwoHRkxVVFRFUhAEEgYKAkdPEAUSCQoFVU5JVFkQBhIQCgxSRUFDVF9OQVRJVkUQBxII'
         'CgRSVVNUEAgSCgoGUFlUSE9OEAkSBwoDQ1BQEAoSDQoJVU5JVFlfV0VCEAsSCAoETk9ERRAMEg'
-        'oKBlVOUkVBTBANEgkKBUVTUDMyEA4iNAoKQ2FwYWJpbGl0eRIOCgpDQVBfVU5VU0VEEAASFgoS'
-        'Q0FQX1BBQ0tFVF9UUkFJTEVSEAE=');
+        'oKBlVOUkVBTBANEgkKBUVTUDMyEA4iVQoKQ2FwYWJpbGl0eRIOCgpDQVBfVU5VU0VEEAASFgoS'
+        'Q0FQX1BBQ0tFVF9UUkFJTEVSEAESHwobQ0FQX0NPTVBSRVNTSU9OX0RFRkxBVEVfUkFXEAI=');
 
 @$core.Deprecated('Use clientConfigurationDescriptor instead')
 const ClientConfiguration$json = {
@@ -1533,7 +1701,7 @@ const DataStream$json = {
     DataStream_Chunk$json,
     DataStream_Trailer$json
   ],
-  '4': [DataStream_OperationType$json],
+  '4': [DataStream_OperationType$json, DataStream_CompressionType$json],
 };
 
 @$core.Deprecated('Use dataStreamDescriptor instead')
@@ -1577,11 +1745,14 @@ const DataStream_Header$json = {
     {'1': 'attributes', '3': 8, '4': 3, '5': 11, '6': '.livekit.DataStream.Header.AttributesEntry', '10': 'attributes'},
     {'1': 'text_header', '3': 9, '4': 1, '5': 11, '6': '.livekit.DataStream.TextHeader', '9': 0, '10': 'textHeader'},
     {'1': 'byte_header', '3': 10, '4': 1, '5': 11, '6': '.livekit.DataStream.ByteHeader', '9': 0, '10': 'byteHeader'},
+    {'1': 'inline_content', '3': 11, '4': 1, '5': 12, '9': 2, '10': 'inlineContent', '17': true},
+    {'1': 'compression', '3': 12, '4': 1, '5': 14, '6': '.livekit.DataStream.CompressionType', '10': 'compression'},
   ],
   '3': [DataStream_Header_AttributesEntry$json],
   '8': [
     {'1': 'content_header'},
     {'1': '_total_length'},
+    {'1': '_inline_content'},
   ],
 };
 
@@ -1658,6 +1829,15 @@ const DataStream_OperationType$json = {
   ],
 };
 
+@$core.Deprecated('Use dataStreamDescriptor instead')
+const DataStream_CompressionType$json = {
+  '1': 'CompressionType',
+  '2': [
+    {'1': 'NONE', '2': 0},
+    {'1': 'DEFLATE_RAW', '2': 1},
+  ],
+};
+
 /// Descriptor for `DataStream`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List dataStreamDescriptor =
     $convert.base64Decode('CgpEYXRhU3RyZWFtGv8BCgpUZXh0SGVhZGVyEkgKDm9wZXJhdGlvbl90eXBlGAEgASgOMiEubG'
@@ -1665,7 +1845,7 @@ final $typed_data.Uint8List dataStreamDescriptor =
         'bhgCIAEoBVIHdmVyc2lvbhI/ChJyZXBseV90b19zdHJlYW1faWQYAyABKAlCErpQD3JlcGx5VG'
         '9TdHJlYW1JRFIPcmVwbHlUb1N0cmVhbUlkEi4KE2F0dGFjaGVkX3N0cmVhbV9pZHMYBCADKAlS'
         'EWF0dGFjaGVkU3RyZWFtSWRzEhwKCWdlbmVyYXRlZBgFIAEoCFIJZ2VuZXJhdGVkGiAKCkJ5dG'
-        'VIZWFkZXISEgoEbmFtZRgBIAEoCVIEbmFtZRqmBAoGSGVhZGVyEigKCXN0cmVhbV9pZBgBIAEo'
+        'VIZWFkZXISEgoEbmFtZRgBIAEoCVIEbmFtZRqsBQoGSGVhZGVyEigKCXN0cmVhbV9pZBgBIAEo'
         'CUILulAIc3RyZWFtSURSCHN0cmVhbUlkEhwKCXRpbWVzdGFtcBgCIAEoA1IJdGltZXN0YW1wEh'
         'QKBXRvcGljGAMgASgJUgV0b3BpYxIbCgltaW1lX3R5cGUYBCABKAlSCG1pbWVUeXBlEiYKDHRv'
         'dGFsX2xlbmd0aBgFIAEoBEgBUgt0b3RhbExlbmd0aIgBARJFCg9lbmNyeXB0aW9uX3R5cGUYBy'
@@ -1673,17 +1853,20 @@ final $typed_data.Uint8List dataStreamDescriptor =
         'dHJpYnV0ZXMYCCADKAsyKi5saXZla2l0LkRhdGFTdHJlYW0uSGVhZGVyLkF0dHJpYnV0ZXNFbn'
         'RyeVIKYXR0cmlidXRlcxJBCgt0ZXh0X2hlYWRlchgJIAEoCzIeLmxpdmVraXQuRGF0YVN0cmVh'
         'bS5UZXh0SGVhZGVySABSCnRleHRIZWFkZXISQQoLYnl0ZV9oZWFkZXIYCiABKAsyHi5saXZla2'
-        'l0LkRhdGFTdHJlYW0uQnl0ZUhlYWRlckgAUgpieXRlSGVhZGVyGj0KD0F0dHJpYnV0ZXNFbnRy'
-        'eRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AjgBQhAKDmNvbnRlbn'
-        'RfaGVhZGVyQg8KDV90b3RhbF9sZW5ndGgapgEKBUNodW5rEigKCXN0cmVhbV9pZBgBIAEoCUIL'
-        'ulAIc3RyZWFtSURSCHN0cmVhbUlkEh8KC2NodW5rX2luZGV4GAIgASgEUgpjaHVua0luZGV4Eh'
-        'gKB2NvbnRlbnQYAyABKAxSB2NvbnRlbnQSGAoHdmVyc2lvbhgEIAEoBVIHdmVyc2lvbhIXCgJp'
-        'dhgFIAEoDEICGAFIAFICaXaIAQFCBQoDX2l2GtcBCgdUcmFpbGVyEigKCXN0cmVhbV9pZBgBIA'
-        'EoCUILulAIc3RyZWFtSURSCHN0cmVhbUlkEhYKBnJlYXNvbhgCIAEoCVIGcmVhc29uEksKCmF0'
-        'dHJpYnV0ZXMYAyADKAsyKy5saXZla2l0LkRhdGFTdHJlYW0uVHJhaWxlci5BdHRyaWJ1dGVzRW'
-        '50cnlSCmF0dHJpYnV0ZXMaPQoPQXR0cmlidXRlc0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQK'
-        'BXZhbHVlGAIgASgJUgV2YWx1ZToCOAEiQQoNT3BlcmF0aW9uVHlwZRIKCgZDUkVBVEUQABIKCg'
-        'ZVUERBVEUQARIKCgZERUxFVEUQAhIMCghSRUFDVElPThAD');
+        'l0LkRhdGFTdHJlYW0uQnl0ZUhlYWRlckgAUgpieXRlSGVhZGVyEioKDmlubGluZV9jb250ZW50'
+        'GAsgASgMSAJSDWlubGluZUNvbnRlbnSIAQESRQoLY29tcHJlc3Npb24YDCABKA4yIy5saXZla2'
+        'l0LkRhdGFTdHJlYW0uQ29tcHJlc3Npb25UeXBlUgtjb21wcmVzc2lvbho9Cg9BdHRyaWJ1dGVz'
+        'RW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4AUIQCg5jb2'
+        '50ZW50X2hlYWRlckIPCg1fdG90YWxfbGVuZ3RoQhEKD19pbmxpbmVfY29udGVudBqmAQoFQ2h1'
+        'bmsSKAoJc3RyZWFtX2lkGAEgASgJQgu6UAhzdHJlYW1JRFIIc3RyZWFtSWQSHwoLY2h1bmtfaW'
+        '5kZXgYAiABKARSCmNodW5rSW5kZXgSGAoHY29udGVudBgDIAEoDFIHY29udGVudBIYCgd2ZXJz'
+        'aW9uGAQgASgFUgd2ZXJzaW9uEhcKAml2GAUgASgMQgIYAUgAUgJpdogBAUIFCgNfaXYa1wEKB1'
+        'RyYWlsZXISKAoJc3RyZWFtX2lkGAEgASgJQgu6UAhzdHJlYW1JRFIIc3RyZWFtSWQSFgoGcmVh'
+        'c29uGAIgASgJUgZyZWFzb24SSwoKYXR0cmlidXRlcxgDIAMoCzIrLmxpdmVraXQuRGF0YVN0cm'
+        'VhbS5UcmFpbGVyLkF0dHJpYnV0ZXNFbnRyeVIKYXR0cmlidXRlcxo9Cg9BdHRyaWJ1dGVzRW50'
+        'cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4ASJBCg1PcGVyYX'
+        'Rpb25UeXBlEgoKBkNSRUFURRAAEgoKBlVQREFURRABEgoKBkRFTEVURRACEgwKCFJFQUNUSU9O'
+        'EAMiLAoPQ29tcHJlc3Npb25UeXBlEggKBE5PTkUQABIPCgtERUZMQVRFX1JBVxAB');
 
 @$core.Deprecated('Use filterParamsDescriptor instead')
 const FilterParams$json = {

--- a/lib/src/proto/livekit_rtc.pb.dart
+++ b/lib/src/proto/livekit_rtc.pb.dart
@@ -43,6 +43,8 @@ enum SignalRequest_Message {
   publishDataTrackRequest,
   unpublishDataTrackRequest,
   updateDataSubscription,
+  storeDataBlobRequest,
+  getDataBlobRequest,
   notSet
 }
 
@@ -68,6 +70,8 @@ class SignalRequest extends $pb.GeneratedMessage {
     PublishDataTrackRequest? publishDataTrackRequest,
     UnpublishDataTrackRequest? unpublishDataTrackRequest,
     UpdateDataSubscription? updateDataSubscription,
+    StoreDataBlobRequest? storeDataBlobRequest,
+    GetDataBlobRequest? getDataBlobRequest,
   }) {
     final result = create();
     if (offer != null) result.offer = offer;
@@ -90,6 +94,8 @@ class SignalRequest extends $pb.GeneratedMessage {
     if (publishDataTrackRequest != null) result.publishDataTrackRequest = publishDataTrackRequest;
     if (unpublishDataTrackRequest != null) result.unpublishDataTrackRequest = unpublishDataTrackRequest;
     if (updateDataSubscription != null) result.updateDataSubscription = updateDataSubscription;
+    if (storeDataBlobRequest != null) result.storeDataBlobRequest = storeDataBlobRequest;
+    if (getDataBlobRequest != null) result.getDataBlobRequest = getDataBlobRequest;
     return result;
   }
 
@@ -122,11 +128,13 @@ class SignalRequest extends $pb.GeneratedMessage {
     19: SignalRequest_Message.publishDataTrackRequest,
     20: SignalRequest_Message.unpublishDataTrackRequest,
     21: SignalRequest_Message.updateDataSubscription,
+    22: SignalRequest_Message.storeDataBlobRequest,
+    23: SignalRequest_Message.getDataBlobRequest,
     0: SignalRequest_Message.notSet
   };
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignalRequest',
       package: const $pb.PackageName(_omitMessageNames ? '' : 'livekit'), createEmptyInstance: create)
-    ..oo(0, [1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])
+    ..oo(0, [1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23])
     ..aOM<SessionDescription>(1, _omitFieldNames ? '' : 'offer', subBuilder: SessionDescription.create)
     ..aOM<SessionDescription>(2, _omitFieldNames ? '' : 'answer', subBuilder: SessionDescription.create)
     ..aOM<TrickleRequest>(3, _omitFieldNames ? '' : 'trickle', subBuilder: TrickleRequest.create)
@@ -154,6 +162,9 @@ class SignalRequest extends $pb.GeneratedMessage {
         subBuilder: UnpublishDataTrackRequest.create)
     ..aOM<UpdateDataSubscription>(21, _omitFieldNames ? '' : 'updateDataSubscription',
         subBuilder: UpdateDataSubscription.create)
+    ..aOM<StoreDataBlobRequest>(22, _omitFieldNames ? '' : 'storeDataBlobRequest',
+        subBuilder: StoreDataBlobRequest.create)
+    ..aOM<GetDataBlobRequest>(23, _omitFieldNames ? '' : 'getDataBlobRequest', subBuilder: GetDataBlobRequest.create)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -193,6 +204,8 @@ class SignalRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(19)
   @$pb.TagNumber(20)
   @$pb.TagNumber(21)
+  @$pb.TagNumber(22)
+  @$pb.TagNumber(23)
   SignalRequest_Message whichMessage() => _SignalRequest_MessageByTag[$_whichOneof(0)]!;
   @$pb.TagNumber(1)
   @$pb.TagNumber(2)
@@ -214,6 +227,8 @@ class SignalRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(19)
   @$pb.TagNumber(20)
   @$pb.TagNumber(21)
+  @$pb.TagNumber(22)
+  @$pb.TagNumber(23)
   void clearMessage() => $_clearField($_whichOneof(0));
 
   /// participant offer for publisher
@@ -456,6 +471,30 @@ class SignalRequest extends $pb.GeneratedMessage {
   void clearUpdateDataSubscription() => $_clearField(21);
   @$pb.TagNumber(21)
   UpdateDataSubscription ensureUpdateDataSubscription() => $_ensure(19);
+
+  /// Store a data blob.
+  @$pb.TagNumber(22)
+  StoreDataBlobRequest get storeDataBlobRequest => $_getN(20);
+  @$pb.TagNumber(22)
+  set storeDataBlobRequest(StoreDataBlobRequest value) => $_setField(22, value);
+  @$pb.TagNumber(22)
+  $core.bool hasStoreDataBlobRequest() => $_has(20);
+  @$pb.TagNumber(22)
+  void clearStoreDataBlobRequest() => $_clearField(22);
+  @$pb.TagNumber(22)
+  StoreDataBlobRequest ensureStoreDataBlobRequest() => $_ensure(20);
+
+  /// Retrieve a stored data blob.
+  @$pb.TagNumber(23)
+  GetDataBlobRequest get getDataBlobRequest => $_getN(21);
+  @$pb.TagNumber(23)
+  set getDataBlobRequest(GetDataBlobRequest value) => $_setField(23, value);
+  @$pb.TagNumber(23)
+  $core.bool hasGetDataBlobRequest() => $_has(21);
+  @$pb.TagNumber(23)
+  void clearGetDataBlobRequest() => $_clearField(23);
+  @$pb.TagNumber(23)
+  GetDataBlobRequest ensureGetDataBlobRequest() => $_ensure(21);
 }
 
 enum SignalResponse_Message {
@@ -487,6 +526,8 @@ enum SignalResponse_Message {
   publishDataTrackResponse,
   unpublishDataTrackResponse,
   dataTrackSubscriberHandles,
+  storeDataBlobResponse,
+  getDataBlobResponse,
   notSet
 }
 
@@ -520,6 +561,8 @@ class SignalResponse extends $pb.GeneratedMessage {
     PublishDataTrackResponse? publishDataTrackResponse,
     UnpublishDataTrackResponse? unpublishDataTrackResponse,
     DataTrackSubscriberHandles? dataTrackSubscriberHandles,
+    StoreDataBlobResponse? storeDataBlobResponse,
+    GetDataBlobResponse? getDataBlobResponse,
   }) {
     final result = create();
     if (join != null) result.join = join;
@@ -550,6 +593,8 @@ class SignalResponse extends $pb.GeneratedMessage {
     if (publishDataTrackResponse != null) result.publishDataTrackResponse = publishDataTrackResponse;
     if (unpublishDataTrackResponse != null) result.unpublishDataTrackResponse = unpublishDataTrackResponse;
     if (dataTrackSubscriberHandles != null) result.dataTrackSubscriberHandles = dataTrackSubscriberHandles;
+    if (storeDataBlobResponse != null) result.storeDataBlobResponse = storeDataBlobResponse;
+    if (getDataBlobResponse != null) result.getDataBlobResponse = getDataBlobResponse;
     return result;
   }
 
@@ -590,11 +635,44 @@ class SignalResponse extends $pb.GeneratedMessage {
     27: SignalResponse_Message.publishDataTrackResponse,
     28: SignalResponse_Message.unpublishDataTrackResponse,
     29: SignalResponse_Message.dataTrackSubscriberHandles,
+    30: SignalResponse_Message.storeDataBlobResponse,
+    31: SignalResponse_Message.getDataBlobResponse,
     0: SignalResponse_Message.notSet
   };
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'SignalResponse',
       package: const $pb.PackageName(_omitMessageNames ? '' : 'livekit'), createEmptyInstance: create)
-    ..oo(0, [1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29])
+    ..oo(0, [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15,
+      16,
+      17,
+      18,
+      19,
+      20,
+      21,
+      22,
+      23,
+      24,
+      25,
+      26,
+      27,
+      28,
+      29,
+      30,
+      31
+    ])
     ..aOM<JoinResponse>(1, _omitFieldNames ? '' : 'join', subBuilder: JoinResponse.create)
     ..aOM<SessionDescription>(2, _omitFieldNames ? '' : 'answer', subBuilder: SessionDescription.create)
     ..aOM<SessionDescription>(3, _omitFieldNames ? '' : 'offer', subBuilder: SessionDescription.create)
@@ -633,6 +711,9 @@ class SignalResponse extends $pb.GeneratedMessage {
         subBuilder: UnpublishDataTrackResponse.create)
     ..aOM<DataTrackSubscriberHandles>(29, _omitFieldNames ? '' : 'dataTrackSubscriberHandles',
         subBuilder: DataTrackSubscriberHandles.create)
+    ..aOM<StoreDataBlobResponse>(30, _omitFieldNames ? '' : 'storeDataBlobResponse',
+        subBuilder: StoreDataBlobResponse.create)
+    ..aOM<GetDataBlobResponse>(31, _omitFieldNames ? '' : 'getDataBlobResponse', subBuilder: GetDataBlobResponse.create)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -680,6 +761,8 @@ class SignalResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(27)
   @$pb.TagNumber(28)
   @$pb.TagNumber(29)
+  @$pb.TagNumber(30)
+  @$pb.TagNumber(31)
   SignalResponse_Message whichMessage() => _SignalResponse_MessageByTag[$_whichOneof(0)]!;
   @$pb.TagNumber(1)
   @$pb.TagNumber(2)
@@ -709,6 +792,8 @@ class SignalResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(27)
   @$pb.TagNumber(28)
   @$pb.TagNumber(29)
+  @$pb.TagNumber(30)
+  @$pb.TagNumber(31)
   void clearMessage() => $_clearField($_whichOneof(0));
 
   /// sent when join is accepted
@@ -1043,6 +1128,30 @@ class SignalResponse extends $pb.GeneratedMessage {
   void clearDataTrackSubscriberHandles() => $_clearField(29);
   @$pb.TagNumber(29)
   DataTrackSubscriberHandles ensureDataTrackSubscriberHandles() => $_ensure(27);
+
+  /// Sent in response to `StoreDataBlobRequest`.
+  @$pb.TagNumber(30)
+  StoreDataBlobResponse get storeDataBlobResponse => $_getN(28);
+  @$pb.TagNumber(30)
+  set storeDataBlobResponse(StoreDataBlobResponse value) => $_setField(30, value);
+  @$pb.TagNumber(30)
+  $core.bool hasStoreDataBlobResponse() => $_has(28);
+  @$pb.TagNumber(30)
+  void clearStoreDataBlobResponse() => $_clearField(30);
+  @$pb.TagNumber(30)
+  StoreDataBlobResponse ensureStoreDataBlobResponse() => $_ensure(28);
+
+  /// Sent in response to `GetDataBlobRequest`.
+  @$pb.TagNumber(31)
+  GetDataBlobResponse get getDataBlobResponse => $_getN(29);
+  @$pb.TagNumber(31)
+  set getDataBlobResponse(GetDataBlobResponse value) => $_setField(31, value);
+  @$pb.TagNumber(31)
+  $core.bool hasGetDataBlobResponse() => $_has(29);
+  @$pb.TagNumber(31)
+  void clearGetDataBlobResponse() => $_clearField(31);
+  @$pb.TagNumber(31)
+  GetDataBlobResponse ensureGetDataBlobResponse() => $_ensure(29);
 }
 
 class SimulcastCodec extends $pb.GeneratedMessage {
@@ -1380,11 +1489,15 @@ class PublishDataTrackRequest extends $pb.GeneratedMessage {
     $core.int? pubHandle,
     $core.String? name,
     $0.Encryption_Type? encryption,
+    $0.DataTrackFrameEncoding? frameEncoding,
+    $0.DataTrackSchemaId? schema,
   }) {
     final result = create();
     if (pubHandle != null) result.pubHandle = pubHandle;
     if (name != null) result.name = name;
     if (encryption != null) result.encryption = encryption;
+    if (frameEncoding != null) result.frameEncoding = frameEncoding;
+    if (schema != null) result.schema = schema;
     return result;
   }
 
@@ -1402,6 +1515,9 @@ class PublishDataTrackRequest extends $pb.GeneratedMessage {
     ..aI(1, _omitFieldNames ? '' : 'pubHandle', fieldType: $pb.PbFieldType.OU3)
     ..aOS(2, _omitFieldNames ? '' : 'name')
     ..aE<$0.Encryption_Type>(3, _omitFieldNames ? '' : 'encryption', enumValues: $0.Encryption_Type.values)
+    ..aOM<$0.DataTrackFrameEncoding>(4, _omitFieldNames ? '' : 'frameEncoding',
+        subBuilder: $0.DataTrackFrameEncoding.create)
+    ..aOM<$0.DataTrackSchemaId>(5, _omitFieldNames ? '' : 'schema', subBuilder: $0.DataTrackSchemaId.create)
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -1453,6 +1569,31 @@ class PublishDataTrackRequest extends $pb.GeneratedMessage {
   $core.bool hasEncryption() => $_has(2);
   @$pb.TagNumber(3)
   void clearEncryption() => $_clearField(3);
+
+  /// Encoding for frame payloads on this track. If unspecified, the track is untyped.
+  @$pb.TagNumber(4)
+  $0.DataTrackFrameEncoding get frameEncoding => $_getN(3);
+  @$pb.TagNumber(4)
+  set frameEncoding($0.DataTrackFrameEncoding value) => $_setField(4, value);
+  @$pb.TagNumber(4)
+  $core.bool hasFrameEncoding() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearFrameEncoding() => $_clearField(4);
+  @$pb.TagNumber(4)
+  $0.DataTrackFrameEncoding ensureFrameEncoding() => $_ensure(3);
+
+  /// ID of the schema used by frames on this track if the track is typed.
+  /// If set, the associated schema must be stored with `StoreDataBlobRequest`.
+  @$pb.TagNumber(5)
+  $0.DataTrackSchemaId get schema => $_getN(4);
+  @$pb.TagNumber(5)
+  set schema($0.DataTrackSchemaId value) => $_setField(5, value);
+  @$pb.TagNumber(5)
+  $core.bool hasSchema() => $_has(4);
+  @$pb.TagNumber(5)
+  void clearSchema() => $_clearField(5);
+  @$pb.TagNumber(5)
+  $0.DataTrackSchemaId ensureSchema() => $_ensure(4);
 }
 
 class PublishDataTrackResponse extends $pb.GeneratedMessage {
@@ -2617,6 +2758,281 @@ class UpdateDataSubscription extends $pb.GeneratedMessage {
 
   @$pb.TagNumber(1)
   $pb.PbList<UpdateDataSubscription_Update> get updates => $_getList(0);
+}
+
+class StoreDataBlobRequest extends $pb.GeneratedMessage {
+  factory StoreDataBlobRequest({
+    $core.int? requestId,
+    $0.DataBlob? blob,
+  }) {
+    final result = create();
+    if (requestId != null) result.requestId = requestId;
+    if (blob != null) result.blob = blob;
+    return result;
+  }
+
+  StoreDataBlobRequest._();
+
+  factory StoreDataBlobRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory StoreDataBlobRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StoreDataBlobRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'livekit'), createEmptyInstance: create)
+    ..aI(1, _omitFieldNames ? '' : 'requestId', fieldType: $pb.PbFieldType.OU3)
+    ..aOM<$0.DataBlob>(2, _omitFieldNames ? '' : 'blob', subBuilder: $0.DataBlob.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  StoreDataBlobRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  StoreDataBlobRequest copyWith(void Function(StoreDataBlobRequest) updates) =>
+      super.copyWith((message) => updates(message as StoreDataBlobRequest)) as StoreDataBlobRequest;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StoreDataBlobRequest create() => StoreDataBlobRequest._();
+  @$core.override
+  StoreDataBlobRequest createEmptyInstance() => create();
+  @$core.pragma('dart2js:noInline')
+  static StoreDataBlobRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StoreDataBlobRequest>(create);
+  static StoreDataBlobRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get requestId => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set requestId($core.int value) => $_setUnsignedInt32(0, value);
+  @$pb.TagNumber(1)
+  $core.bool hasRequestId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearRequestId() => $_clearField(1);
+
+  @$pb.TagNumber(2)
+  $0.DataBlob get blob => $_getN(1);
+  @$pb.TagNumber(2)
+  set blob($0.DataBlob value) => $_setField(2, value);
+  @$pb.TagNumber(2)
+  $core.bool hasBlob() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearBlob() => $_clearField(2);
+  @$pb.TagNumber(2)
+  $0.DataBlob ensureBlob() => $_ensure(1);
+}
+
+class StoreDataBlobResponse extends $pb.GeneratedMessage {
+  factory StoreDataBlobResponse({
+    $core.int? requestId,
+    $0.DataBlobKey? key,
+  }) {
+    final result = create();
+    if (requestId != null) result.requestId = requestId;
+    if (key != null) result.key = key;
+    return result;
+  }
+
+  StoreDataBlobResponse._();
+
+  factory StoreDataBlobResponse.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory StoreDataBlobResponse.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'StoreDataBlobResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'livekit'), createEmptyInstance: create)
+    ..aI(1, _omitFieldNames ? '' : 'requestId', fieldType: $pb.PbFieldType.OU3)
+    ..aOM<$0.DataBlobKey>(2, _omitFieldNames ? '' : 'key', subBuilder: $0.DataBlobKey.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  StoreDataBlobResponse clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  StoreDataBlobResponse copyWith(void Function(StoreDataBlobResponse) updates) =>
+      super.copyWith((message) => updates(message as StoreDataBlobResponse)) as StoreDataBlobResponse;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static StoreDataBlobResponse create() => StoreDataBlobResponse._();
+  @$core.override
+  StoreDataBlobResponse createEmptyInstance() => create();
+  @$core.pragma('dart2js:noInline')
+  static StoreDataBlobResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<StoreDataBlobResponse>(create);
+  static StoreDataBlobResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get requestId => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set requestId($core.int value) => $_setUnsignedInt32(0, value);
+  @$pb.TagNumber(1)
+  $core.bool hasRequestId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearRequestId() => $_clearField(1);
+
+  /// Unique key the data blob was stored under.
+  @$pb.TagNumber(2)
+  $0.DataBlobKey get key => $_getN(1);
+  @$pb.TagNumber(2)
+  set key($0.DataBlobKey value) => $_setField(2, value);
+  @$pb.TagNumber(2)
+  $core.bool hasKey() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearKey() => $_clearField(2);
+  @$pb.TagNumber(2)
+  $0.DataBlobKey ensureKey() => $_ensure(1);
+}
+
+class GetDataBlobRequest extends $pb.GeneratedMessage {
+  factory GetDataBlobRequest({
+    $core.int? requestId,
+    $core.String? participantIdentity,
+    $0.DataBlobKey? key,
+  }) {
+    final result = create();
+    if (requestId != null) result.requestId = requestId;
+    if (participantIdentity != null) result.participantIdentity = participantIdentity;
+    if (key != null) result.key = key;
+    return result;
+  }
+
+  GetDataBlobRequest._();
+
+  factory GetDataBlobRequest.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory GetDataBlobRequest.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetDataBlobRequest',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'livekit'), createEmptyInstance: create)
+    ..aI(1, _omitFieldNames ? '' : 'requestId', fieldType: $pb.PbFieldType.OU3)
+    ..aOS(2, _omitFieldNames ? '' : 'participantIdentity')
+    ..aOM<$0.DataBlobKey>(3, _omitFieldNames ? '' : 'key', subBuilder: $0.DataBlobKey.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  GetDataBlobRequest clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  GetDataBlobRequest copyWith(void Function(GetDataBlobRequest) updates) =>
+      super.copyWith((message) => updates(message as GetDataBlobRequest)) as GetDataBlobRequest;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetDataBlobRequest create() => GetDataBlobRequest._();
+  @$core.override
+  GetDataBlobRequest createEmptyInstance() => create();
+  @$core.pragma('dart2js:noInline')
+  static GetDataBlobRequest getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetDataBlobRequest>(create);
+  static GetDataBlobRequest? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get requestId => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set requestId($core.int value) => $_setUnsignedInt32(0, value);
+  @$pb.TagNumber(1)
+  $core.bool hasRequestId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearRequestId() => $_clearField(1);
+
+  /// Identity of the participant who owns the blob.
+  @$pb.TagNumber(2)
+  $core.String get participantIdentity => $_getSZ(1);
+  @$pb.TagNumber(2)
+  set participantIdentity($core.String value) => $_setString(1, value);
+  @$pb.TagNumber(2)
+  $core.bool hasParticipantIdentity() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearParticipantIdentity() => $_clearField(2);
+
+  /// Unique key of the data blob to retrieve.
+  @$pb.TagNumber(3)
+  $0.DataBlobKey get key => $_getN(2);
+  @$pb.TagNumber(3)
+  set key($0.DataBlobKey value) => $_setField(3, value);
+  @$pb.TagNumber(3)
+  $core.bool hasKey() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearKey() => $_clearField(3);
+  @$pb.TagNumber(3)
+  $0.DataBlobKey ensureKey() => $_ensure(2);
+}
+
+class GetDataBlobResponse extends $pb.GeneratedMessage {
+  factory GetDataBlobResponse({
+    $core.int? requestId,
+    $0.DataBlob? blob,
+  }) {
+    final result = create();
+    if (requestId != null) result.requestId = requestId;
+    if (blob != null) result.blob = blob;
+    return result;
+  }
+
+  GetDataBlobResponse._();
+
+  factory GetDataBlobResponse.fromBuffer($core.List<$core.int> data,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(data, registry);
+  factory GetDataBlobResponse.fromJson($core.String json,
+          [$pb.ExtensionRegistry registry = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(json, registry);
+
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'GetDataBlobResponse',
+      package: const $pb.PackageName(_omitMessageNames ? '' : 'livekit'), createEmptyInstance: create)
+    ..aI(1, _omitFieldNames ? '' : 'requestId', fieldType: $pb.PbFieldType.OU3)
+    ..aOM<$0.DataBlob>(2, _omitFieldNames ? '' : 'blob', subBuilder: $0.DataBlob.create)
+    ..hasRequiredFields = false;
+
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  GetDataBlobResponse clone() => deepCopy();
+  @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
+  GetDataBlobResponse copyWith(void Function(GetDataBlobResponse) updates) =>
+      super.copyWith((message) => updates(message as GetDataBlobResponse)) as GetDataBlobResponse;
+
+  @$core.override
+  $pb.BuilderInfo get info_ => _i;
+
+  @$core.pragma('dart2js:noInline')
+  static GetDataBlobResponse create() => GetDataBlobResponse._();
+  @$core.override
+  GetDataBlobResponse createEmptyInstance() => create();
+  @$core.pragma('dart2js:noInline')
+  static GetDataBlobResponse getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GetDataBlobResponse>(create);
+  static GetDataBlobResponse? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get requestId => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set requestId($core.int value) => $_setUnsignedInt32(0, value);
+  @$pb.TagNumber(1)
+  $core.bool hasRequestId() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearRequestId() => $_clearField(1);
+
+  @$pb.TagNumber(2)
+  $0.DataBlob get blob => $_getN(1);
+  @$pb.TagNumber(2)
+  set blob($0.DataBlob value) => $_setField(2, value);
+  @$pb.TagNumber(2)
+  $core.bool hasBlob() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearBlob() => $_clearField(2);
+  @$pb.TagNumber(2)
+  $0.DataBlob ensureBlob() => $_ensure(1);
 }
 
 class UpdateTrackSettings extends $pb.GeneratedMessage {

--- a/lib/src/proto/livekit_rtc.pbenum.dart
+++ b/lib/src/proto/livekit_rtc.pbenum.dart
@@ -98,6 +98,8 @@ class RequestResponse_Reason extends $pb.ProtobufEnum {
       RequestResponse_Reason._(9, _omitEnumNames ? '' : 'DUPLICATE_HANDLE');
   static const RequestResponse_Reason DUPLICATE_NAME =
       RequestResponse_Reason._(10, _omitEnumNames ? '' : 'DUPLICATE_NAME');
+  static const RequestResponse_Reason INVALID_REQUEST =
+      RequestResponse_Reason._(11, _omitEnumNames ? '' : 'INVALID_REQUEST');
 
   static const $core.List<RequestResponse_Reason> values = <RequestResponse_Reason>[
     OK,
@@ -111,9 +113,10 @@ class RequestResponse_Reason extends $pb.ProtobufEnum {
     INVALID_NAME,
     DUPLICATE_HANDLE,
     DUPLICATE_NAME,
+    INVALID_REQUEST,
   ];
 
-  static final $core.List<RequestResponse_Reason?> _byValue = $pb.ProtobufEnum.$_initByValueList(values, 10);
+  static final $core.List<RequestResponse_Reason?> _byValue = $pb.ProtobufEnum.$_initByValueList(values, 11);
   static RequestResponse_Reason? valueOf($core.int value) =>
       value < 0 || value >= _byValue.length ? null : _byValue[value];
 

--- a/lib/src/proto/livekit_rtc.pbjson.dart
+++ b/lib/src/proto/livekit_rtc.pbjson.dart
@@ -144,6 +144,24 @@ const SignalRequest$json = {
       '9': 0,
       '10': 'updateDataSubscription'
     },
+    {
+      '1': 'store_data_blob_request',
+      '3': 22,
+      '4': 1,
+      '5': 11,
+      '6': '.livekit.StoreDataBlobRequest',
+      '9': 0,
+      '10': 'storeDataBlobRequest'
+    },
+    {
+      '1': 'get_data_blob_request',
+      '3': 23,
+      '4': 1,
+      '5': 11,
+      '6': '.livekit.GetDataBlobRequest',
+      '9': 0,
+      '10': 'getDataBlobRequest'
+    },
   ],
   '8': [
     {'1': 'message'},
@@ -176,7 +194,10 @@ final $typed_data.Uint8List signalRequestDescriptor =
         'JlcXVlc3QYFCABKAsyIi5saXZla2l0LlVucHVibGlzaERhdGFUcmFja1JlcXVlc3RIAFIZdW5w'
         'dWJsaXNoRGF0YVRyYWNrUmVxdWVzdBJbChh1cGRhdGVfZGF0YV9zdWJzY3JpcHRpb24YFSABKA'
         'syHy5saXZla2l0LlVwZGF0ZURhdGFTdWJzY3JpcHRpb25IAFIWdXBkYXRlRGF0YVN1YnNjcmlw'
-        'dGlvbkIJCgdtZXNzYWdl');
+        'dGlvbhJWChdzdG9yZV9kYXRhX2Jsb2JfcmVxdWVzdBgWIAEoCzIdLmxpdmVraXQuU3RvcmVEYX'
+        'RhQmxvYlJlcXVlc3RIAFIUc3RvcmVEYXRhQmxvYlJlcXVlc3QSUAoVZ2V0X2RhdGFfYmxvYl9y'
+        'ZXF1ZXN0GBcgASgLMhsubGl2ZWtpdC5HZXREYXRhQmxvYlJlcXVlc3RIAFISZ2V0RGF0YUJsb2'
+        'JSZXF1ZXN0QgkKB21lc3NhZ2U=');
 
 @$core.Deprecated('Use signalResponseDescriptor instead')
 const SignalResponse$json = {
@@ -330,6 +351,24 @@ const SignalResponse$json = {
       '9': 0,
       '10': 'dataTrackSubscriberHandles'
     },
+    {
+      '1': 'store_data_blob_response',
+      '3': 30,
+      '4': 1,
+      '5': 11,
+      '6': '.livekit.StoreDataBlobResponse',
+      '9': 0,
+      '10': 'storeDataBlobResponse'
+    },
+    {
+      '1': 'get_data_blob_response',
+      '3': 31,
+      '4': 1,
+      '5': 11,
+      '6': '.livekit.GetDataBlobResponse',
+      '9': 0,
+      '10': 'getDataBlobResponse'
+    },
   ],
   '8': [
     {'1': 'message'},
@@ -374,7 +413,10 @@ final $typed_data.Uint8List signalResponseDescriptor =
         'VraXQuVW5wdWJsaXNoRGF0YVRyYWNrUmVzcG9uc2VIAFIadW5wdWJsaXNoRGF0YVRyYWNrUmVz'
         'cG9uc2USaAodZGF0YV90cmFja19zdWJzY3JpYmVyX2hhbmRsZXMYHSABKAsyIy5saXZla2l0Lk'
         'RhdGFUcmFja1N1YnNjcmliZXJIYW5kbGVzSABSGmRhdGFUcmFja1N1YnNjcmliZXJIYW5kbGVz'
-        'QgkKB21lc3NhZ2U=');
+        'ElkKGHN0b3JlX2RhdGFfYmxvYl9yZXNwb25zZRgeIAEoCzIeLmxpdmVraXQuU3RvcmVEYXRhQm'
+        'xvYlJlc3BvbnNlSABSFXN0b3JlRGF0YUJsb2JSZXNwb25zZRJTChZnZXRfZGF0YV9ibG9iX3Jl'
+        'c3BvbnNlGB8gASgLMhwubGl2ZWtpdC5HZXREYXRhQmxvYlJlc3BvbnNlSABSE2dldERhdGFCbG'
+        '9iUmVzcG9uc2VCCQoHbWVzc2FnZQ==');
 
 @$core.Deprecated('Use simulcastCodecDescriptor instead')
 const SimulcastCodec$json = {
@@ -471,6 +513,21 @@ const PublishDataTrackRequest$json = {
     {'1': 'pub_handle', '3': 1, '4': 1, '5': 13, '10': 'pubHandle'},
     {'1': 'name', '3': 2, '4': 1, '5': 9, '10': 'name'},
     {'1': 'encryption', '3': 3, '4': 1, '5': 14, '6': '.livekit.Encryption.Type', '10': 'encryption'},
+    {
+      '1': 'frame_encoding',
+      '3': 4,
+      '4': 1,
+      '5': 11,
+      '6': '.livekit.DataTrackFrameEncoding',
+      '9': 0,
+      '10': 'frameEncoding',
+      '17': true
+    },
+    {'1': 'schema', '3': 5, '4': 1, '5': 11, '6': '.livekit.DataTrackSchemaId', '9': 1, '10': 'schema', '17': true},
+  ],
+  '8': [
+    {'1': '_frame_encoding'},
+    {'1': '_schema'},
   ],
 };
 
@@ -478,7 +535,10 @@ const PublishDataTrackRequest$json = {
 final $typed_data.Uint8List publishDataTrackRequestDescriptor =
     $convert.base64Decode('ChdQdWJsaXNoRGF0YVRyYWNrUmVxdWVzdBIdCgpwdWJfaGFuZGxlGAEgASgNUglwdWJIYW5kbG'
         'USEgoEbmFtZRgCIAEoCVIEbmFtZRI4CgplbmNyeXB0aW9uGAMgASgOMhgubGl2ZWtpdC5FbmNy'
-        'eXB0aW9uLlR5cGVSCmVuY3J5cHRpb24=');
+        'eXB0aW9uLlR5cGVSCmVuY3J5cHRpb24SSwoOZnJhbWVfZW5jb2RpbmcYBCABKAsyHy5saXZla2'
+        'l0LkRhdGFUcmFja0ZyYW1lRW5jb2RpbmdIAFINZnJhbWVFbmNvZGluZ4gBARI3CgZzY2hlbWEY'
+        'BSABKAsyGi5saXZla2l0LkRhdGFUcmFja1NjaGVtYUlkSAFSBnNjaGVtYYgBAUIRCg9fZnJhbW'
+        'VfZW5jb2RpbmdCCQoHX3NjaGVtYQ==');
 
 @$core.Deprecated('Use publishDataTrackResponseDescriptor instead')
 const PublishDataTrackResponse$json = {
@@ -795,6 +855,64 @@ final $typed_data.Uint8List updateDataSubscriptionDescriptor =
         'Rpb25zGAMgASgLMiUubGl2ZWtpdC5EYXRhVHJhY2tTdWJzY3JpcHRpb25PcHRpb25zUgdvcHRp'
         'b25z');
 
+@$core.Deprecated('Use storeDataBlobRequestDescriptor instead')
+const StoreDataBlobRequest$json = {
+  '1': 'StoreDataBlobRequest',
+  '2': [
+    {'1': 'request_id', '3': 1, '4': 1, '5': 13, '8': {}, '10': 'requestId'},
+    {'1': 'blob', '3': 2, '4': 1, '5': 11, '6': '.livekit.DataBlob', '10': 'blob'},
+  ],
+};
+
+/// Descriptor for `StoreDataBlobRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List storeDataBlobRequestDescriptor =
+    $convert.base64Decode('ChRTdG9yZURhdGFCbG9iUmVxdWVzdBIrCgpyZXF1ZXN0X2lkGAEgASgNQgy6UAlyZXF1ZXN0SU'
+        'RSCXJlcXVlc3RJZBIlCgRibG9iGAIgASgLMhEubGl2ZWtpdC5EYXRhQmxvYlIEYmxvYg==');
+
+@$core.Deprecated('Use storeDataBlobResponseDescriptor instead')
+const StoreDataBlobResponse$json = {
+  '1': 'StoreDataBlobResponse',
+  '2': [
+    {'1': 'request_id', '3': 1, '4': 1, '5': 13, '8': {}, '10': 'requestId'},
+    {'1': 'key', '3': 2, '4': 1, '5': 11, '6': '.livekit.DataBlobKey', '10': 'key'},
+  ],
+};
+
+/// Descriptor for `StoreDataBlobResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List storeDataBlobResponseDescriptor =
+    $convert.base64Decode('ChVTdG9yZURhdGFCbG9iUmVzcG9uc2USKwoKcmVxdWVzdF9pZBgBIAEoDUIMulAJcmVxdWVzdE'
+        'lEUglyZXF1ZXN0SWQSJgoDa2V5GAIgASgLMhQubGl2ZWtpdC5EYXRhQmxvYktleVIDa2V5');
+
+@$core.Deprecated('Use getDataBlobRequestDescriptor instead')
+const GetDataBlobRequest$json = {
+  '1': 'GetDataBlobRequest',
+  '2': [
+    {'1': 'request_id', '3': 1, '4': 1, '5': 13, '8': {}, '10': 'requestId'},
+    {'1': 'participant_identity', '3': 2, '4': 1, '5': 9, '10': 'participantIdentity'},
+    {'1': 'key', '3': 3, '4': 1, '5': 11, '6': '.livekit.DataBlobKey', '10': 'key'},
+  ],
+};
+
+/// Descriptor for `GetDataBlobRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getDataBlobRequestDescriptor =
+    $convert.base64Decode('ChJHZXREYXRhQmxvYlJlcXVlc3QSKwoKcmVxdWVzdF9pZBgBIAEoDUIMulAJcmVxdWVzdElEUg'
+        'lyZXF1ZXN0SWQSMQoUcGFydGljaXBhbnRfaWRlbnRpdHkYAiABKAlSE3BhcnRpY2lwYW50SWRl'
+        'bnRpdHkSJgoDa2V5GAMgASgLMhQubGl2ZWtpdC5EYXRhQmxvYktleVIDa2V5');
+
+@$core.Deprecated('Use getDataBlobResponseDescriptor instead')
+const GetDataBlobResponse$json = {
+  '1': 'GetDataBlobResponse',
+  '2': [
+    {'1': 'request_id', '3': 1, '4': 1, '5': 13, '8': {}, '10': 'requestId'},
+    {'1': 'blob', '3': 2, '4': 1, '5': 11, '6': '.livekit.DataBlob', '10': 'blob'},
+  ],
+};
+
+/// Descriptor for `GetDataBlobResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List getDataBlobResponseDescriptor =
+    $convert.base64Decode('ChNHZXREYXRhQmxvYlJlc3BvbnNlEisKCnJlcXVlc3RfaWQYASABKA1CDLpQCXJlcXVlc3RJRF'
+        'IJcmVxdWVzdElkEiUKBGJsb2IYAiABKAsyES5saXZla2l0LkRhdGFCbG9iUgRibG9i');
+
 @$core.Deprecated('Use updateTrackSettingsDescriptor instead')
 const UpdateTrackSettings$json = {
   '1': 'UpdateTrackSettings',
@@ -922,11 +1040,11 @@ const UpdateParticipantMetadata_AttributesEntry$json = {
 
 /// Descriptor for `UpdateParticipantMetadata`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List updateParticipantMetadataDescriptor =
-    $convert.base64Decode('ChlVcGRhdGVQYXJ0aWNpcGFudE1ldGFkYXRhEkAKCG1ldGFkYXRhGAEgASgJQiSoUAGyUB48cm'
-        'VkYWN0ZWQgKHt7IC5TaXplIH19IGJ5dGVzKT5SCG1ldGFkYXRhEjgKBG5hbWUYAiABKAlCJKhQ'
-        'AbJQHjxyZWRhY3RlZCAoe3sgLlNpemUgfX0gYnl0ZXMpPlIEbmFtZRJ4CgphdHRyaWJ1dGVzGA'
+    $convert.base64Decode('ChlVcGRhdGVQYXJ0aWNpcGFudE1ldGFkYXRhEkAKCG1ldGFkYXRhGAEgASgJQiSyUB48cmVkYW'
+        'N0ZWQgKHt7IC5TaXplIH19IGJ5dGVzKT7AUAFSCG1ldGFkYXRhEjgKBG5hbWUYAiABKAlCJLJQ'
+        'HjxyZWRhY3RlZCAoe3sgLlNpemUgfX0gYnl0ZXMpPsBQAVIEbmFtZRJ4CgphdHRyaWJ1dGVzGA'
         'MgAygLMjIubGl2ZWtpdC5VcGRhdGVQYXJ0aWNpcGFudE1ldGFkYXRhLkF0dHJpYnV0ZXNFbnRy'
-        'eUIkqFABslAePHJlZGFjdGVkICh7eyAuU2l6ZSB9fSBieXRlcyk+UgphdHRyaWJ1dGVzEisKCn'
+        'eUIkslAePHJlZGFjdGVkICh7eyAuU2l6ZSB9fSBieXRlcyk+wFABUgphdHRyaWJ1dGVzEisKCn'
         'JlcXVlc3RfaWQYBCABKA1CDLpQCXJlcXVlc3RJRFIJcmVxdWVzdElkGj0KD0F0dHJpYnV0ZXNF'
         'bnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AjgB');
 
@@ -942,8 +1060,8 @@ const ICEServer$json = {
 
 /// Descriptor for `ICEServer`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List iCEServerDescriptor =
-    $convert.base64Decode('CglJQ0VTZXJ2ZXISEgoEdXJscxgBIAMoCVIEdXJscxIfCgh1c2VybmFtZRgCIAEoCUIDqFABUg'
-        'h1c2VybmFtZRIjCgpjcmVkZW50aWFsGAMgASgJQgOoUAFSCmNyZWRlbnRpYWw=');
+    $convert.base64Decode('CglJQ0VTZXJ2ZXISEgoEdXJscxgBIAMoCVIEdXJscxIfCgh1c2VybmFtZRgCIAEoCUIDwFABUg'
+        'h1c2VybmFtZRIjCgpjcmVkZW50aWFsGAMgASgJQgPAUAJSCmNyZWRlbnRpYWw=');
 
 @$core.Deprecated('Use speakersChangedDescriptor instead')
 const SpeakersChanged$json = {
@@ -1434,6 +1552,7 @@ const RequestResponse_Reason$json = {
     {'1': 'INVALID_NAME', '2': 8},
     {'1': 'DUPLICATE_HANDLE', '2': 9},
     {'1': 'DUPLICATE_NAME', '2': 10},
+    {'1': 'INVALID_REQUEST', '2': 11},
   ],
 };
 
@@ -1451,11 +1570,12 @@ final $typed_data.Uint8List requestResponseDescriptor =
         'l0LlVwZGF0ZUxvY2FsVmlkZW9UcmFja0gAUhB1cGRhdGVWaWRlb1RyYWNrElAKEnB1Ymxpc2hf'
         'ZGF0YV90cmFjaxgKIAEoCzIgLmxpdmVraXQuUHVibGlzaERhdGFUcmFja1JlcXVlc3RIAFIQcH'
         'VibGlzaERhdGFUcmFjaxJWChR1bnB1Ymxpc2hfZGF0YV90cmFjaxgLIAEoCzIiLmxpdmVraXQu'
-        'VW5wdWJsaXNoRGF0YVRyYWNrUmVxdWVzdEgAUhJ1bnB1Ymxpc2hEYXRhVHJhY2sizgEKBlJlYX'
+        'VW5wdWJsaXNoRGF0YVRyYWNrUmVxdWVzdEgAUhJ1bnB1Ymxpc2hEYXRhVHJhY2si4wEKBlJlYX'
         'NvbhIGCgJPSxAAEg0KCU5PVF9GT1VORBABEg8KC05PVF9BTExPV0VEEAISEgoOTElNSVRfRVhD'
         'RUVERUQQAxIKCgZRVUVVRUQQBBIUChBVTlNVUFBPUlRFRF9UWVBFEAUSFgoSVU5DTEFTU0lGSU'
         'VEX0VSUk9SEAYSEgoOSU5WQUxJRF9IQU5ETEUQBxIQCgxJTlZBTElEX05BTUUQCBIUChBEVVBM'
-        'SUNBVEVfSEFORExFEAkSEgoORFVQTElDQVRFX05BTUUQCkIJCgdyZXF1ZXN0');
+        'SUNBVEVfSEFORExFEAkSEgoORFVQTElDQVRFX05BTUUQChITCg9JTlZBTElEX1JFUVVFU1QQC0'
+        'IJCgdyZXF1ZXN0');
 
 @$core.Deprecated('Use trackSubscribedDescriptor instead')
 const TrackSubscribed$json = {
@@ -1541,10 +1661,10 @@ const JoinRequest_ParticipantAttributesEntry$json = {
 final $typed_data.Uint8List joinRequestDescriptor =
     $convert.base64Decode('CgtKb2luUmVxdWVzdBI0CgtjbGllbnRfaW5mbxgBIAEoCzITLmxpdmVraXQuQ2xpZW50SW5mb1'
         'IKY2xpZW50SW5mbxJMChNjb25uZWN0aW9uX3NldHRpbmdzGAIgASgLMhsubGl2ZWtpdC5Db25u'
-        'ZWN0aW9uU2V0dGluZ3NSEmNvbm5lY3Rpb25TZXR0aW5ncxJACghtZXRhZGF0YRgDIAEoCUIkqF'
-        'ABslAePHJlZGFjdGVkICh7eyAuU2l6ZSB9fSBieXRlcyk+UghtZXRhZGF0YRKMAQoWcGFydGlj'
+        'ZWN0aW9uU2V0dGluZ3NSEmNvbm5lY3Rpb25TZXR0aW5ncxJACghtZXRhZGF0YRgDIAEoCUIksl'
+        'AePHJlZGFjdGVkICh7eyAuU2l6ZSB9fSBieXRlcyk+wFABUghtZXRhZGF0YRKMAQoWcGFydGlj'
         'aXBhbnRfYXR0cmlidXRlcxgEIAMoCzIvLmxpdmVraXQuSm9pblJlcXVlc3QuUGFydGljaXBhbn'
-        'RBdHRyaWJ1dGVzRW50cnlCJKhQAbJQHjxyZWRhY3RlZCAoe3sgLlNpemUgfX0gYnl0ZXMpPlIV'
+        'RBdHRyaWJ1dGVzRW50cnlCJLJQHjxyZWRhY3RlZCAoe3sgLlNpemUgfX0gYnl0ZXMpPsBQAVIV'
         'cGFydGljaXBhbnRBdHRyaWJ1dGVzEkYKEmFkZF90cmFja19yZXF1ZXN0cxgFIAMoCzIYLmxpdm'
         'VraXQuQWRkVHJhY2tSZXF1ZXN0UhBhZGRUcmFja1JlcXVlc3RzEkQKD3B1Ymxpc2hlcl9vZmZl'
         'chgGIAEoCzIbLmxpdmVraXQuU2Vzc2lvbkRlc2NyaXB0aW9uUg5wdWJsaXNoZXJPZmZlchIcCg'


### PR DESCRIPTION
Regenerates the protobuf bindings from livekit/protocol v1.50.4 (`make proto && make format`).

All changes are additive:

- New data track messages: `DataTrackFrameEncoding`, `DataTrackSchemaEncoding`, `DataTrackSchemaId`
- New data blob messages: `DataBlobKey`, `DataBlob`, `StoreDataBlobRequest/Response`, `GetDataBlobRequest/Response`
- New enum values: `PacketTrailerFeature.PTF_USER_DATA`, `ParticipantInfo_KindDetail.SIMULATION`, `RequestResponse_Reason.INVALID_REQUEST`, `ClientInfo_Capability.CAP_COMPRESSION_DEFLATE_RAW`
- New fields: `ParticipantInfo.capabilities`, `MetricsRecordingHeader.jobId` + simulation/redaction fields, `DataStream.Header.inline_content`/`compression`

`flutter analyze` and `flutter test` pass (390 tests).