### PR TITLE
Guard adaptive stream after track removal

### DIFF
--- a/lib/src/publication/remote.dart
+++ b/lib/src/publication/remote.dart
@@ -160,7 +160,9 @@ class RemoteTrackPublication<T extends RemoteTrack> extends TrackPublication<T> 
           max(s1.height, s2.height),
         );
 
-    final videoTrack = track as VideoTrack;
+    final currentTrack = track;
+    if (currentTrack is! VideoTrack) return;
+    final videoTrack = currentTrack as VideoTrack;
 
     // Filter visible build contexts and scale each view's logical size by its
     // own pixel density, so the server is asked for physical-pixel dimensions

--- a/test/publication/remote_track_publication_test.dart
+++ b/test/publication/remote_track_publication_test.dart
@@ -235,6 +235,40 @@ void main() {
       expect(manualSettings!.disabled, isTrue, reason: 'manual video settings should keep hidden tracks disabled');
       expect(manualSettings.quality, lk_models.VideoQuality.LOW);
     });
+
+    test('stale video view callback is ignored after track removal', () async {
+      await room.dispose();
+      await connectTestRoom(
+        roomOptions: const RoomOptions(adaptiveStream: true),
+      );
+
+      final participant = room.remoteParticipants.values.first;
+      const sid = 'TR_remote_pub_adaptive_removed';
+      final pub = RemoteTrackPublication<RemoteVideoTrack>(
+        participant: participant,
+        info: lk_models.TrackInfo(
+          sid: sid,
+          name: 'video',
+          type: lk_models.TrackType.VIDEO,
+        ),
+      );
+      addTearDown(() async => await pub.dispose());
+
+      final stream = _FakeMediaStream('stream-$sid');
+      final mediaTrack = _FakeMediaStreamTrack(id: sid, kind: 'video');
+      await stream.addTrack(mediaTrack);
+      final videoTrack = RemoteVideoTrack(
+        TrackSource.camera,
+        stream,
+        mediaTrack,
+      );
+
+      await pub.updateTrack(videoTrack);
+      await pub.updateTrack(null);
+
+      expect(videoTrack.onVideoViewBuild, isNotNull);
+      expect(videoTrack.onVideoViewBuild!, returnsNormally);
+    });
   });
 }
 


### PR DESCRIPTION
## What changed

- Guard adaptive-stream visibility callbacks when the publication no longer has a video track.
- Add a regression test for a stale video-view callback after track removal.

## Root cause

`RemoteTrackPublication` leaves the video track's `onVideoViewBuild` callback installed after `updateTrack(null)`. If that stale callback runs, `_computeVideoViewVisibility` force-casts the publication's null track to `VideoTrack` and throws a runtime type error.

## Impact

Stale callbacks now stop without changing normal adaptive-stream behavior. Valid video tracks follow the existing path.

## Validation

- The regression test fails before the guard with `type 'Null' is not a subtype of type 'VideoTrack' in type cast`.
- `flutter test --no-pub --timeout 20s --reporter expanded test/publication/remote_track_publication_test.dart`
- `flutter analyze --no-pub lib/src/publication/remote.dart test/publication/remote_track_publication_test.dart`
