### PR TITLE
Honor discardFrameWhenCryptorNotReady in BaseKeyProvider.create

### DIFF
--- a/.changes/key-provider-discard-frame-option
+++ b/.changes/key-provider-discard-frame-option
@@ -1,0 +1,1 @@
+patch type="fixed" "BaseKeyProvider.create now honors the discardFrameWhenCryptorNotReady option instead of always using the default"

--- a/lib/src/e2ee/key_provider.dart
+++ b/lib/src/e2ee/key_provider.dart
@@ -82,7 +82,7 @@ class BaseKeyProvider implements KeyProvider {
         uncryptedMagicBytes: Uint8List.fromList((uncryptedMagicBytes ?? defaultMagicBytes).codeUnits),
         failureTolerance: failureTolerance ?? defaultFailureTolerance,
         keyRingSize: keyRingSize ?? defaultKeyRingSize,
-        discardFrameWhenCryptorNotReady: defaultDiscardFrameWhenCryptorNotReady);
+        discardFrameWhenCryptorNotReady: discardFrameWhenCryptorNotReady ?? defaultDiscardFrameWhenCryptorNotReady);
     final keyProvider = await rtc.frameCryptorFactory.createDefaultKeyProvider(options);
     return BaseKeyProvider(keyProvider, options);
   }


### PR DESCRIPTION
BaseKeyProvider.create accepted a discardFrameWhenCryptorNotReady parameter but never read it, every call got the built-in default. Now follows the same param-or-default pattern as the sibling options.

Pre-existing bug surfaced by Devin on the #1170 reformat diff, fixed separately to keep that PR mechanical.