### PR TITLE
Configure the audio session before recording starts, not only on connect

### DIFF
--- a/lib/src/audio/audio_manager.dart
+++ b/lib/src/audio/audio_manager.dart
@@ -81,6 +81,11 @@ class AudioManager {
   bool _forceSpeakerOutput = false;
   bool _isPlayoutEnabled = false;
   bool _isRecordingEnabled = false;
+  // Whether an Apple audio session policy has been pushed to native at least
+  // once. Native caches the last policy it was given and has no category to
+  // apply until something has been pushed, which is what [prepareRecording]
+  // checks before pushing one itself.
+  bool _hasPushedAppleSessionPolicy = false;
   final StreamController<AudioEngineState> _audioEngineStateController = StreamController<AudioEngineState>.broadcast();
 
   AudioSessionOptions get options => _options;
@@ -124,6 +129,7 @@ class AudioManager {
     _forceSpeakerOutput = false;
     _isPlayoutEnabled = false;
     _isRecordingEnabled = false;
+    _hasPushedAppleSessionPolicy = false;
   }
 
   /// Invoked from native when the WebRTC audio engine's playout/recording state
@@ -310,6 +316,7 @@ class AudioManager {
           selectCategoryByEngineState: true,
           forceSpeakerOutput: policy.forceSpeakerOutput,
         );
+        _hasPushedAppleSessionPolicy = true;
       } else {
         // Manual mode: re-apply the fixed Apple config. Non-forced receiver vs
         // speaker behavior comes from that config. Force is carried separately
@@ -327,6 +334,30 @@ class AudioManager {
     } else if (lkPlatformIs(PlatformType.android)) {
       await _configureAndroidAudioSession(_options);
     }
+  }
+
+  /// Prepares the platform audio session for recording.
+  ///
+  /// On iOS the audio engine refuses to open the microphone unless the audio
+  /// session already permits recording, and LiveKit owns that session. The
+  /// policy is normally pushed on connect, but recording can start earlier —
+  /// pre-connect audio buffering, or a pre-join microphone preview — so this is
+  /// called for every local audio track before its capture starts.
+  ///
+  /// Does nothing once a policy has been pushed, so it never re-applies a
+  /// configuration to a live session, and nothing in
+  /// [AudioSessionManagementMode.manual], where the app owns the session and is
+  /// responsible for a recording-capable category. iOS only; a no-op elsewhere,
+  /// so it is always safe to call from cross-platform code.
+  ///
+  /// Experimental: this API may change in a future release.
+  @experimental
+  Future<void> prepareRecording() async {
+    if (!lkPlatformIs(PlatformType.iOS)) return;
+    if (_hasPushedAppleSessionPolicy) return;
+    await _syncAppleAudioSessionManagementMode();
+    if (!_isAutomaticConfigurationEnabled) return;
+    await _configureAppleAudioSession(_options);
   }
 
   @internal
@@ -360,6 +391,7 @@ class AudioManager {
       selectCategoryByEngineState: _isAutomaticConfigurationEnabled,
       forceSpeakerOutput: policy.forceSpeakerOutput,
     );
+    _hasPushedAppleSessionPolicy = true;
   }
 
   Future<void> _configureAndroidAudioSession(AudioSessionOptions options) async {

--- a/lib/src/track/audio_management.dart
+++ b/lib/src/track/audio_management.dart
@@ -30,6 +30,12 @@ class NativeAudioManagement {
     await AudioManager.instance.applyOptionsForConnect();
   }
 
+  /// Makes sure the platform audio session permits recording before a local
+  /// audio track opens the microphone, which can happen before connect.
+  static Future<void> prepareRecording() async {
+    await AudioManager.instance.prepareRecording();
+  }
+
   static Future<void> stop() async {
     // Release mirrors acquire: applyOptionsForConnect starts the Android
     // audio session in every mode except manual, including externalCallSystem,

--- a/lib/src/track/local/audio.dart
+++ b/lib/src/track/local/audio.dart
@@ -86,6 +86,10 @@ class LocalAudioTrack extends LocalTrack with AudioTrack, LocalAudioManagementMi
   Future<void> startCapture() async {
     await super.startCapture();
     if (lkPlatformSupportsExplicitAudioRecordingStart()) {
+      // The audio engine rejects recording while the audio session does not
+      // permit it, and capture can start before connect has pushed the session
+      // policy (pre-connect audio, a pre-join preview). No-op once pushed.
+      await NativeAudioManagement.prepareRecording();
       try {
         // Match Swift: start the ADM before publishing so capture-time audio
         // processing options are applied before WebRTC opens the microphone.

--- a/test/audio/audio_session_test.dart
+++ b/test/audio/audio_session_test.dart
@@ -603,6 +603,12 @@ void main() {
       expect(calls.single.arguments, {'enabled': true, 'sessionActivationEnabled': false});
     });
 
+    test('prepareRecording leaves the platform alone off iOS', () async {
+      await AudioManager.instance.prepareRecording();
+
+      expect(calls, isEmpty);
+    });
+
     test('passes engine availability to platform method', () async {
       await Native.setEngineAvailability(isInputAvailable: false, isOutputAvailable: true);
 


### PR DESCRIPTION
On iOS the audio engine refuses to open the microphone unless the audio session already permits recording, and livekit_client owns that session: it disables flutter_webrtc's own session management at plugin registration (`LiveKitPlugin.swift`, `setAudioSessionManagementEnabled(false)`). But the policy was only pushed to native from `Room.connect` — `NativeAudioManagement.start()` → `AudioManager.applyOptionsForConnect()` → `configureNativeAudio` — so any recording that starts earlier ran against the app-default `soloAmbient` category. The engine's pre-enable check rejects that with `kAudioEngineErrorAudioSessionInvalidCategory` (-9001), surfacing as `AudioProcessingException(applyFailed): Audio engine returned error code: -9001`.

That is the default path for agent sessions: `SessionOptions.preConnectAudio` defaults to true, and `withPreConnectAudio` buffers the microphone before connect. Because `startRecording` throws before `connect` is reached, the native policy cache is never seeded, so it fails on every attempt rather than only the first. A pre-join microphone preview hits the same wall with no pre-connect audio involved, which is how #1165 was reported.

The fix pushes the policy from the capture path instead, where the microphone actually opens: `LocalAudioTrack.startCapture` calls the new `AudioManager.prepareRecording()` just before `Native.startLocalRecording`. That one choke point covers pre-connect buffering, a standalone pre-join track, and normal mic publish.

`prepareRecording()` is deliberately narrow. It is a no-op off iOS, a no-op in `AudioSessionManagementMode.manual` (the app owns the session and is responsible for a recording-capable category), and a no-op once a policy has been pushed — tracked by a new `_hasPushedAppleSessionPolicy` flag set at both existing Apple push sites. That last guard is not just an optimization: re-pushing mid-call while the engine has playout only would resolve the *playback* category through `selectCategoryByEngineState` and apply it moments before recording starts, so the guard keeps this off the hot path entirely.

The added unit test only asserts the off-iOS no-op — `lkPlatform()` reads `dart:io Platform` with no override hook, so no test in this repo can reach an iOS-gated branch. `flutter analyze`, `flutter test`, `dart format --set-exit-if-changed` and `import_sorter --exit-if-changed` are all clean.

## How this went unnoticed

The precondition was never explicit. `PreConnectAudioBuffer` (#830) opens the microphone outside the room lifecycle by design, and nothing stated who guarantees the session permits recording — it was satisfied incidentally, by flutter_webrtc's `ensureAudioSession` on `getUserMedia` and by track-counting that fired on *publish*, which a pre-connect track has not reached.

Two commits in 2.9.0, a day apart, removed that cover and then made the failure loud:

- #1108 (`55af814`) took sole ownership of the iOS session: it is where `setAudioSessionManagementEnabled(false)` first appears, killing flutter_webrtc's incidental configuration, and where track-counting became engine-driven lifecycle whose only Dart entry point is connect. After it, no path configures the session before connect.
- #1115 (`d1fe342`) moved the ADM start into `LocalAudioTrack.startCapture` and made it fail-fast. Its description mentions the preconnect path, but the review lens there was audio *processing options*, so the session category beside it went unexamined. Combined with the fork's specific error codes, a latent misconfiguration became a named hard failure.

The fail-fast was not the mistake — it exposed the real one. #1042 reports what looks like the same path failing at 2.7.0 with the generic `adm api failed with code: -1`, five months earlier, which is likely the same root cause under a code too vague to act on.

Two things kept it out of test range:

- CI's iOS job is `flutter build ios --release --no-codesign` — a compile, with no simulator or device run.
- Unit tests cannot reach the code at all: `lkPlatform()` reads `dart:io Platform` with no seam, so on the test host every iOS-gated branch in `AudioManager` is unreachable. The existing audio tests cover policy resolution and channel argument encoding — pure Dart either side of the platform gate, never the gate itself.

Worth considering separately from this PR: the native pre-enable check is gated `#if !TARGET_OS_OSX`, so it runs on the simulator too — driving the example app through connect-with-mic there would have caught this end to end, and is the only layer that would have. A test seam for `lkPlatform()` would make these branches assertable at all, and `willEnableEngine` finding `cachedConfiguration` nil is worth logging loudly rather than silently returning proceed and letting the native check fail a layer later.

Fixes #1165

## Testing

I tested this locally with the Flutter Agent Starter:
- Without the fix I run into #1165.
- With the fix it works