### PR TITLE
fix(ci): unbreak Dart Format and Dart Analyze on main

### DIFF
--- a/.changes/caching-token-source-await
+++ b/.changes/caching-token-source-await
@@ -1,1 +1,1 @@
-patch type="fixed" "CachingTokenSource.fetch now awaits its result inside the try block, so failures reach the catch clause and the in-flight request entry is cleared only once the request settles"
+patch type="fixed" "CachingTokenSource.fetch now awaits its result, so errors surface and the in-flight entry is cleared correctly"

--- a/.changes/caching-token-source-await
+++ b/.changes/caching-token-source-await
@@ -1,0 +1,1 @@
+patch type="fixed" "CachingTokenSource.fetch now awaits its result inside the try block, so failures reach the catch clause and the in-flight request entry is cleared only once the request settles"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,6 +66,12 @@ jobs:
       - uses: ./.github/actions/setup-flutter
       - name: Dart Analyze Check
         run: flutter analyze
+      # `flutter analyze` runs Flutter's AnalysisOptionsMigration first, which
+      # forces `web/**` into analysis_options.yaml. This package keeps real Dart
+      # source there (the E2EE worker), so analyze it separately -- `dart
+      # analyze` does not run migrators.
+      - name: Dart Analyze Check (web sources)
+        run: dart analyze web/
 
   dart-test-check:
     name: Dart Test

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -33,6 +33,18 @@ analyzer:
     # Manager is enabled and this package ships Package.swift.
     - build/**
     - example/build/**
+    # Flutter's AnalysisOptionsMigration (flutter_tools) appends these seven
+    # patterns to this file on every `flutter analyze`/`pub get`/`run`. There is
+    # no opt-out, so they are committed here to stop the file being rewritten.
+    # Note this excludes web/, which in this package holds real Dart source (the
+    # E2EE worker) rather than just assets -- CI analyzes it explicitly with
+    # `dart analyze web/`, which does not run migrators.
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 linter:
   rules:

--- a/lib/src/token_source/caching.dart
+++ b/lib/src/token_source/caching.dart
@@ -135,13 +135,13 @@ class CachingTokenSource implements TokenSourceConfigurable {
       final cached = await _store.retrieve();
       if (cached != null && cached.options == options && _validator(cached.options, cached.response)) {
         completer.complete(cached.response);
-        return resultFuture;
+        return await resultFuture;
       }
 
       final response = await _wrapped.fetch(options);
       await _store.store(options, response);
       completer.complete(response);
-      return resultFuture;
+      return await resultFuture;
     } catch (e, stackTrace) {
       completer.completeError(e, stackTrace);
       rethrow;

--- a/scripts/check_version.dart
+++ b/scripts/check_version.dart
@@ -1,4 +1,5 @@
 #!/usr/bin/env dart
+
 /*
  * Copyright 2025 LiveKit
  *

--- a/scripts/create_change.dart
+++ b/scripts/create_change.dart
@@ -1,4 +1,5 @@
 #!/usr/bin/env dart
+
 /*
  * Copyright 2025 LiveKit
  *

--- a/scripts/create_version.dart
+++ b/scripts/create_version.dart
@@ -1,4 +1,5 @@
 #!/usr/bin/env dart
+
 /*
  * Copyright 2025 LiveKit
  *

--- a/web/analysis_options.yaml
+++ b/web/analysis_options.yaml
@@ -1,0 +1,33 @@
+#
+# Copyright 2025 LiveKit
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The repository-root analysis_options.yaml has to exclude `web/**`: Flutter's
+# AnalysisOptionsMigration appends that pattern on every `flutter analyze` and
+# offers no way to opt out. These files are real Dart source (the E2EE worker),
+# not web assets, so this file gives them their own analysis context and keeps
+# them covered. CI analyzes them via `dart analyze web/`.
+
+include: package:lints/recommended.yaml
+
+analyzer:
+  errors:
+    constant_identifier_names: ignore
+    use_super_parameters: ignore
+    avoid_print: ignore
+    deprecated_member_use_from_same_package: ignore
+
+formatter:
+  page_width: 120
+  trailing_commas: preserve

--- a/web/analysis_options.yaml
+++ b/web/analysis_options.yaml
@@ -28,6 +28,18 @@ analyzer:
     avoid_print: ignore
     deprecated_member_use_from_same_package: ignore
 
+linter:
+  rules:
+    # Preference of the SDK
+    prefer_single_quotes: true
+    prefer_final_locals: true
+    unnecessary_brace_in_string_interps: false
+    avoid_print: true
+
+    # Enforce this for correct async logic
+    unawaited_futures: true
+    discarded_futures: true
+
 formatter:
   page_width: 120
   trailing_commas: preserve


### PR DESCRIPTION
`Build` has been failing on `main` and therefore on every PR, regardless of what the PR changes — visible on #1180, `max/fix-ios-audio-session-before-recording` and `sync-upstream-2.11.0`, all of which show `Build ✗` with `Changeset Check ✓`. Two jobs are responsible.

## Dart Format

Three files under `scripts/` are not formatted, so `dart format . --set-exit-if-changed` exits 1. Straight from the CI log:

```
Formatted scripts/check_version.dart
Formatted scripts/create_change.dart
Formatted scripts/create_version.dart
Formatted 227 files (3 changed) in 0.72 seconds.
##[error]Process completed with exit code 1
```

Formatting only, no behaviour change.

## Dart Analyze

```
lib/src/token_source/caching.dart:138:9 • unawaited_return_in_try_block
lib/src/token_source/caching.dart:144:7 • unawaited_return_in_try_block
```

`CachingTokenSource.fetch` returned `resultFuture` from inside its `try`, so the surrounding `catch` could not observe a failure from that future and `finally` removed the in-flight entry before it settled. Both returns now `await`.

Behaviour is unchanged — the completer is completed on the line immediately before each return, so the awaited future is already resolved — but errors now route through the existing `catch`, and the in-flight map is cleared only once the request settles. `AGENTS.md` calls out un-awaited async state updates as a recurring bug class here, so this is a real latent issue rather than a lint silence. Includes a `patch type="fixed"` changeset.

## The analysis_options churn, and a coverage hole it was hiding

`flutter analyze` kept leaving `analysis_options.yaml` modified. The cause is `AnalysisOptionsMigration` (`flutter_tools/lib/src/migrations/analysis_options_migration.dart`, invoked from `project.dart:429`), which appends seven patterns — `build/**`, `android/**`, `ios/**`, `web/**`, `windows/**`, `macos/**`, `linux/**` — on every `flutter analyze` / `pub get` / `run`. It is unconditional; there is no feature flag or config to disable it, unlike the UIScene migrator's `enable-uiscene-migration`.

Committing the patterns makes it a no-op. But one of them matters: **this package keeps real Dart source in `web/`** (the E2EE worker), not just assets, so `web/**` silently drops it from analysis. That was already happening in CI, since `flutter analyze` runs the migrator before it analyzes.

Passing the path explicitly does **not** work — `dart analyze web/` still honours the root exclude. I confirmed this by appending a deliberate type error to `web/e2ee.logger.dart`: it reported `No issues found!`. Giving `web/` its own `analysis_options.yaml` creates a separate context that is genuinely analyzed; the same canary then correctly reports `return_of_invalid_type`. That file mirrors the root's error overrides and its formatter settings (`page_width: 120`, `trailing_commas: preserve`) so `dart format` output is unaffected, and `build.yaml` gains a `dart analyze web/` step.

## Verified locally

```
dart format . --set-exit-if-changed   PASS  (227 files, 0 changed)
flutter analyze                        PASS  (No issues found)
dart analyze web/                      PASS  (and fails on an injected error)
flutter test                           PASS  (+398)
dart run scripts/check_version.dart    PASS
import_sorter --exit-if-changed        PASS
```

## Not included

Pinning the Flutter version in `.github/actions/setup-flutter/action.yml`, which currently passes only `channel: stable` and so tracks whatever the newest stable release is. That is a genuine fragility — `unawaited_return_in_try_block` arrived this way — but it is a separate decision from unbreaking CI, and worth its own discussion.

Draft because #1180 should confirm this actually turns `Build` green once rebased on it.