### PR TITLE
Declare the UTF-8 byte length in the sendText stream header

### DIFF
--- a/.changes/utf8-send-text
+++ b/.changes/utf8-send-text
@@ -1,0 +1,1 @@
+patch type="fixed" "sendText declares the UTF-8 byte length in the stream header, fixing rejected text streams containing non-ASCII characters"

--- a/lib/src/participant/local.dart
+++ b/lib/src/participant/local.dart
@@ -15,6 +15,7 @@
 // ignore_for_file: deprecated_member_use_from_same_package
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 import 'dart:typed_data' show Uint8List;
@@ -1034,8 +1035,7 @@ class LocalParticipant extends Participant<LocalTrackPublication> {
 extension DataStreamParticipantMethods on LocalParticipant {
   Future<TextStreamInfo> sendText(String text, {SendTextOptions? options}) async {
     final streamId = Uuid().v4();
-    final textInBytes = text.codeUnits;
-    final totalTextLength = textInBytes.length;
+    final totalTextLength = utf8.encode(text).length;
 
     final fileIds = options?.attachments.map((f) => Uuid().v4()).toList();
     var len = 0;

--- a/test/core/data_stream_test.dart
+++ b/test/core/data_stream_test.dart
@@ -74,6 +74,24 @@ void main() {
       expect(info, isNotNull);
     });
 
+    test('Send Text Message With UTF-8 Byte Length For Special Characters', () async {
+      const text = 'Café résumé – emoji 😀';
+
+      room.registerTextStreamHandler('chat-utf8', (TextStreamReader reader, String participantIdentity) async {
+        final received = await reader.readAll();
+        expect(received, text);
+        expect(reader.info!.size, utf8.encode(text).length);
+      });
+
+      final info = await room.localParticipant?.sendText(
+        text,
+        options: SendTextOptions(
+          topic: 'chat-utf8',
+        ),
+      );
+      expect(info, isNotNull);
+    });
+
     test('Send Large Text Message With Progress Tracking', () async {
       final longText = 'a' * 100000;
 

--- a/test/core/data_stream_test.dart
+++ b/test/core/data_stream_test.dart
@@ -77,10 +77,17 @@ void main() {
     test('Send Text Message With UTF-8 Byte Length For Special Characters', () async {
       const text = 'Café résumé – emoji 😀';
 
+      // Completed by the handler so the test cannot pass without the
+      // assertions on the received stream having run.
+      final received = Completer<void>();
       room.registerTextStreamHandler('chat-utf8', (TextStreamReader reader, String participantIdentity) async {
-        final received = await reader.readAll();
-        expect(received, text);
-        expect(reader.info!.size, utf8.encode(text).length);
+        try {
+          expect(await reader.readAll(), text);
+          expect(reader.info!.size, utf8.encode(text).length);
+          received.complete();
+        } catch (error, stackTrace) {
+          received.completeError(error, stackTrace);
+        }
       });
 
       final info = await room.localParticipant?.sendText(
@@ -90,6 +97,7 @@ void main() {
         ),
       );
       expect(info, isNotNull);
+      await received.future.timeout(const Duration(seconds: 5));
     });
 
     test('Send Large Text Message With Progress Tracking', () async {


### PR DESCRIPTION
**Description**
sendText() currently calculates the total stream size using text.codeUnits.length.

This does not correspond to the actual number of bytes produced when the text is encoded as UTF-8. As a result, messages containing non-ASCII characters such as accented characters or emojis can cause the receiver to reject the stream with:

StreamError: read length exceeded total length specified in stream header

For example, é is one UTF-16 code unit but requires two bytes in UTF-8.

**Fix**

Use the UTF-8 encoded byte length when setting the total stream size:

final textInBytes = utf8.encode(text);
final totalTextLength = textInBytes.length;

This ensures that the size declared in the stream header matches the actual UTF-8 payload size.

**Testing**

Tested with messages containing:

ASCII characters
Accented characters (é, à, è, etc.)
Emojis
Multibyte Unicode characters

Before this change, messages containing accented characters could trigger the StreamError. After the change, they are correctly received by the LiveKit Agents backend.

**Related issue**

Fixes #1054