### PR TITLE
fix(engine): close the peer connection after announcing the disconnect

### DIFF
--- a/lib/src/core/engine.dart
+++ b/lib/src/core/engine.dart
@@ -1113,15 +1113,28 @@ class Engine extends Disposable with EventsEmittable<EngineEvent> {
         unawaited(handleReconnect(ClientDisconnectReason.reconnectRetry));
       } else {
         logger.fine('attemptReconnect: disconnecting...');
-        // clean up before emitting, room's EngineDisconnectedEvent handler
-        // drops the event while fullReconnectOnNext is still true and
-        // cleanUp() is what resets it
-        await cleanUp();
+        // Reset only the flag the Room gates on, then announce, then tear down.
+        //
+        // `room.dart` drops EngineDisconnectedEvent while `fullReconnectOnNext` is still
+        // true, and `cleanUp()` is what resets it — which is why the cleanUp was moved
+        // ahead of the emit. But `cleanUp()` also disposes the transports, i.e.
+        // `pc.close()` + `pc.dispose()` on the native peer connection, so the whole
+        // teardown ran before anything had been told the connection was gone.
+        //
+        // On iOS that closes a peer connection whose ICE machinery is still live,
+        // moments after failed reconnect attempts were driving it. libwebrtc m144 then
+        // faults on the network thread: the platform thread blocks in
+        // `[peerConnection close]` while a queued ICE task dereferences NULL.
+        //
+        // Clearing the flag is all the emit needs, so the native close can stay where it
+        // belongs — after every listener has been told the connection dropped.
+        fullReconnectOnNext = false;
         events.emit(EngineDisconnectedEvent(
           reason: e is CertificatePinningException
               ? DisconnectReason.signalingConnectionFailure
               : DisconnectReason.disconnected,
         ));
+        await cleanUp();
       }
     } finally {
       _attemptingReconnect = false;


### PR DESCRIPTION
`Engine.attemptReconnect`'s give-up branch runs `cleanUp()` before emitting EngineDisconnectedEvent. `cleanUp()` disposes the transports — `pc.close()` and `pc.dispose()` on the native peer connection — so the connection is destroyed while the Room and the application still believe they are connected, moments after failed reconnect attempts have been driving ICE.

On iOS this faults inside libwebrtc. The platform thread blocks in `[peerConnection close]` (flutter_webrtc FlutterWebRTCPlugin.m) while the ICE network thread dispatches a still-queued task and dereferences NULL:

    Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
    Exception Subtype: KERN_INVALID_ADDRESS at 0x0000000000000028

    Thread 0:                          Thread N Crashed:
      _pthread_cond_wait                 webrtc::Port::SharedSocket() const
      [peerConnection close]             webrtc::CreateIceTransport(...)
      FlutterMethodChannel handler       webrtc::Thread::Dispatch(...)

Reproduced on four TestFlight builds with the app backgrounded and the connection dropped underneath it (an idle server-side disconnect three times, a server redeploy once) — every one routes through this branch, because a sleeping phone has no network for the reconnect attempts to succeed on.

The ordering was deliberate: `room.dart` drops EngineDisconnectedEvent while `fullReconnectOnNext` is still true, and `cleanUp()` is what resets it, so emitting first left the application stuck believing it was connected. That is a real bug and this keeps it fixed — but resetting one boolean does not require running the whole teardown first. Clear the flag, emit, then clean up.

Behaviour is otherwise unchanged: `cleanUp()` still runs on the same path and still sets `fullReconnectOnNext = false` itself, so the assignment is redundant by the time it is reached.