### PR TITLE
Do not fail audio capture when local recording pre-warm fails on Android

### DIFF
--- a/.changes/android-prewarm-recording-non-fatal
+++ b/.changes/android-prewarm-recording-non-fatal
@@ -1,0 +1,1 @@
+patch type="fixed" "Android: a failed local recording pre-warm no longer aborts microphone capture with AudioProcessingException(applyFailed)"

--- a/android/src/main/kotlin/io/livekit/plugin/LiveKitPlugin.kt
+++ b/android/src/main/kotlin/io/livekit/plugin/LiveKitPlugin.kt
@@ -19,6 +19,7 @@ package io.livekit.plugin
 import android.annotation.SuppressLint
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import androidx.annotation.NonNull
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -276,8 +277,18 @@ class LiveKitPlugin : FlutterPlugin, MethodCallHandler {
             result.success(null)
           }
         } catch (error: Throwable) {
+          // Pre-warming is best effort. prewarmRecording() applies the platform
+          // audio processing options before it prepares the recorder, so the
+          // options are in effect even when preparing fails, and WebRTC opens
+          // the recorder again on the real start path and reports its own
+          // init/start errors there. Surfacing this as applyFailed instead
+          // aborts startCapture() and fails the publish outright on devices
+          // that cannot open an AudioRecord yet (microphone held by another
+          // app, vendor capture restrictions) — an audio processing failure
+          // the requested options never caused.
+          Log.w(TAG, "Failed to prewarm local recording, continuing without it", error)
           mainHandler.post {
-            result.error("applyFailed", error.message, null)
+            result.success(null)
           }
         }
       }
@@ -478,5 +489,9 @@ class LiveKitPlugin : FlutterPlugin, MethodCallHandler {
     // Cleanup all processors
     audioProcessors.values.forEach { it.cleanup() }
     audioProcessors.clear()
+  }
+
+  companion object {
+    private const val TAG = "LiveKitPlugin"
   }
 }


### PR DESCRIPTION
## Problem

`LocalAudioTrack.startCapture()` calls `Native.startLocalRecording(...)` before publishing. On Android, `handleStartLocalRecording` catches every `Throwable` from `JavaAudioDeviceModule.prewarmRecording(options)` and reports it as `applyFailed`, which Dart converts into `AudioProcessingException` and rethrows out of `startCapture()`, aborting the publish.

On devices where WebRTC cannot open an `AudioRecord` at that moment, the pre-warm throws `java.lang.AssertionError: Expected condition to be true`, so the app sees

```
AudioProcessingException(applyFailed): Expected condition to be true
```

and the microphone is never published — although nothing is wrong with the requested audio processing options, and the assertion text says nothing an application can act on.

### Why the assertion fires

In webrtc-sdk `144.7559.09`, the pinned native build:

```java
public void prewarmRecording(@Nullable AudioProcessingOptions options) {
  audioInput.applyPlatformAudioProcessingOptions(options);
  audioInput.initRecordingIfNeeded();     // boolean result discarded
  audioInput.prewarmRecordingIfNeeded();
}
```

`initRecordingIfNeeded()` returns `false` when `AudioRecord` creation or initialization fails — the microphone is already captured by another process, a vendor capture restriction applies, or `getMinBufferSize` rejects the configuration. That result is discarded, and `initAudioRecord()` has already called `releaseAudioResources()`, which leaves `audioRecord` null. `prewarmRecordingIfNeeded()` then runs anyway and reaches `startRecordingImpl()`:

```java
assertTrue(audioThread == null);
if (useAudioRecord) {
  assertTrue(audioRecord != null);   // throws AssertionError here
```

The real reason for the failure is only in logcat under `WebRtcAudioRecordExternal` ("Creation or initialization of audio recorder failed.", "AudioRecord.getMinBufferSize failed: ...").

The same assertion has been reported against the Android SDK in livekit/client-sdk-android#700.

## Fix

Treat the pre-warm as best effort: log the failure and let capture continue.

- **The processing options are already applied.** `applyPlatformAudioProcessingOptions(options)` is the first statement of `prewarmRecording`, so the reason the pre-warm exists — applying capture-time processing before WebRTC opens the microphone — is still satisfied when the later recorder preparation fails.
- **WebRTC opens the recorder again on the real start path.** Because the failed attempt leaves `audioRecord` null, the native `initRecording()` re-enters `initRecordingImpl()` when the track is actually published, and failures there are reported through the audio device module's own recording callbacks. Aborting at pre-warm time removes that second attempt entirely, which turns a transiently busy microphone into a permanent publish failure.
- **A recorder that cannot be prepared is not an audio processing failure.** Reporting it as `applyFailed` is misleading, and it makes `AudioProcessingException` mean two different things. After this change the exception keeps its documented meaning, that the requested options could not be applied, and `AudioManager.getAudioProcessingState()` still reports the resolved state.

The iOS and macOS paths are unchanged.

## Reproducing

On Android, hold the microphone with another application, then publish the mic.

- Before: `startCapture()` throws `AudioProcessingException(applyFailed): Expected condition to be true` and the track is never published.
- After: a warning is logged under the `LiveKitPlugin` tag, the publish proceeds, and the recorder is opened again on the normal start path.

## Notes

- Includes a `patch` / `fixed` changeset.
- No automated test: reproducing it needs a device on which `AudioRecord` creation fails, and the Android plugin has no instrumentation-test harness here. `:livekit_client:compileDebugKotlin` and the existing `:livekit_client` unit tests pass.
