### PR TITLE
fix: Hotfix for flutter-webrtc 1.6.2.

### DIFF
--- a/.changes/hotfix-for-flutter-webrtc-1.6.2
+++ b/.changes/hotfix-for-flutter-webrtc-1.6.2
@@ -1,0 +1,1 @@
+minor type="changed" "Bump flutter-webrtc to 1.6.2+hotfix.1, fixed crash on Linux/Windows and fix resource leak by releasing event channel on Darwin"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   json_annotation: ^4.12.0
 
   # Fix version to avoid version conflicts between WebRTC-SDK pods, which both this package and flutter_webrtc depend on.
-  flutter_webrtc: 1.6.2
+  flutter_webrtc: 1.6.2+hotfix.1
   dart_webrtc: ^1.8.0
 
 dev_dependencies:


### PR DESCRIPTION
# Some important updates from flutter-webrtc 1.6.2+hotfix.1.

* fix(android): guard null cameraName before reuse check in getUserMedia by @dev-ahmedhany in https://github.com/flutter-webrtc/flutter-webrtc/pull/2166
* fix(darwin): fix resource leak by releasing event channel stream handlers by @gfx in https://github.com/flutter-webrtc/flutter-webrtc/pull/2167
* fix: Do not access the WebRTC API before calling EnsureWebRTCInitialized by @cloudwebrtc in https://github.com/flutter-webrtc/flutter-webrtc/pull/2169