### PR TITLE
fix: session migration triggers a full reconnect instead of a resume

### DIFF
--- a/.changes/migration-leave-resumes-instead-of-full-reconnect
+++ b/.changes/migration-leave-resumes-instead-of-full-reconnect
@@ -1,0 +1,1 @@
+patch type="fixed" "Session migration (server `Leave{action: RESUME}`) now resumes the session instead of escalating to a full reconnect, so remote participants are no longer dropped and re-added"

--- a/lib/src/core/engine.dart
+++ b/lib/src/core/engine.dart
@@ -1126,9 +1126,12 @@ class Engine extends Disposable with EventsEmittable<EngineEvent> {
       return;
     }
 
+    // `leaveReconnect` is intentionally not escalated here: since protocol v13 a server
+    // Leave carries an action, and `RESUME` (what the server sends for a node migration)
+    // must stay a resume. The callers that need a full reconnect (`RECONNECT` leave,
+    // connection check) set `fullReconnectOnNext` themselves before handing over.
     if (_clientConfiguration?.resumeConnection == lk_models.ClientConfigSetting.DISABLED ||
         [
-          ClientDisconnectReason.leaveReconnect,
           ClientDisconnectReason.negotiationFailed,
           ClientDisconnectReason.peerConnectionFailed,
         ].contains(reason)) {
@@ -1526,7 +1529,9 @@ class Engine extends Disposable with EventsEmittable<EngineEvent> {
       // canReconnect is still checked for backward compatibility with v12 servers
       // (where action defaults to DISCONNECT=0 since it's unset).
       if (event.action == lk_rtc.LeaveRequest_Action.RESUME) {
-        fullReconnectOnNext = false;
+        // The server (e.g. a node migration) expects us to resume the session, so
+        // fullReconnectOnNext is deliberately left alone rather than forced to false:
+        // an escalation from an already-failed resume must not be downgraded here.
         // reconnect immediately instead of waiting for next attempt
         await handleReconnect(ClientDisconnectReason.leaveReconnect);
       } else if (event.action == lk_rtc.LeaveRequest_Action.RECONNECT || event.canReconnect) {

--- a/test/core/leave_action_test.dart
+++ b/test/core/leave_action_test.dart
@@ -70,12 +70,22 @@ void main() {
     final sub = room.events.listen(roomEvents.add);
     final previousHandlers = ws.handlers;
 
+    // The server also drops the socket right after the Leave, but that is
+    // deliberately not simulated here: a bare socket drop reconnects with reason
+    // `signal`, which resumes on its own. Delivering it before the leave-driven
+    // attempt runs (in production it arrives a round-trip later, so it never
+    // wins) makes this test pass even when the leave action is ignored entirely.
     sendLeave(lk_rtc.LeaveRequest_Action.RESUME, lk_models.DisconnectReason.MIGRATION);
 
     await answerReconnectAttempt(previousHandlers);
     await room.events.waitFor<RoomReconnectedEvent>(duration: const Duration(seconds: 5));
     await sub();
 
+    expect(
+      ws.uri?.queryParameters['reconnect'],
+      '1',
+      reason: 'a resume must re-open the signal connection with reconnect=1',
+    );
     expect(
       roomEvents.whereType<RoomResumingEvent>(),
       isNotEmpty,

--- a/test/core/leave_action_test.dart
+++ b/test/core/leave_action_test.dart
@@ -1,0 +1,124 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@Timeout(Duration(seconds: 10))
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:livekit_client/livekit_client.dart';
+import 'package:livekit_client/src/proto/livekit_models.pb.dart' as lk_models;
+import 'package:livekit_client/src/proto/livekit_rtc.pb.dart' as lk_rtc;
+import '../mock/e2e_container.dart';
+import '../mock/peerconnection_mock.dart';
+import '../mock/websocket_mock.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late E2EContainer container;
+  late Room room;
+  late MockWebSocketConnector ws;
+
+  setUp(() async {
+    resetMockDataChannels();
+    container = E2EContainer();
+    room = container.room;
+    ws = container.wsConnector;
+    await container.connectRoom();
+  });
+
+  tearDown(() async {
+    await container.dispose();
+  });
+
+  /// Feed a server-initiated `LeaveRequest` into the signal connection.
+  void sendLeave(lk_rtc.LeaveRequest_Action action, lk_models.DisconnectReason reason) {
+    ws.onData(
+      lk_rtc.SignalResponse(
+        leave: lk_rtc.LeaveRequest(action: action, reason: reason),
+      ).writeToBuffer(),
+    );
+  }
+
+  /// Wait until the SDK has opened a *new* websocket (the reconnect attempt),
+  /// then answer it the way the receiving node would.
+  Future<void> answerReconnectAttempt(Object? previousHandlers) async {
+    for (var i = 0; i < 200 && identical(ws.handlers, previousHandlers); i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+    expect(identical(ws.handlers, previousHandlers), isFalse, reason: 'SDK never re-opened the signal connection');
+    ws.onData(lk_rtc.SignalResponse(reconnect: lk_rtc.ReconnectResponse()).writeToBuffer());
+  }
+
+  test('Leave{RESUME} (node migration) resumes and keeps remote participants', () async {
+    await container.simulateRemoteParticipantJoin('bob');
+    expect(room.remoteParticipants, hasLength(1));
+
+    final roomEvents = <RoomEvent>[];
+    final sub = room.events.listen(roomEvents.add);
+    final previousHandlers = ws.handlers;
+
+    sendLeave(lk_rtc.LeaveRequest_Action.RESUME, lk_models.DisconnectReason.MIGRATION);
+
+    await answerReconnectAttempt(previousHandlers);
+    await room.events.waitFor<RoomReconnectedEvent>(duration: const Duration(seconds: 5));
+    await sub();
+
+    expect(
+      roomEvents.whereType<RoomResumingEvent>(),
+      isNotEmpty,
+      reason: 'a migration must resume the session',
+    );
+    expect(
+      roomEvents.whereType<RoomReconnectingEvent>(),
+      isEmpty,
+      reason: 'RoomReconnectingEvent signals a full reconnect, which drops session state',
+    );
+    expect(
+      roomEvents.whereType<ParticipantDisconnectedEvent>(),
+      isEmpty,
+      reason: 'a migration must not kick out remote participants',
+    );
+    expect(room.remoteParticipants, hasLength(1));
+    expect(container.engine.fullReconnectOnNext, isFalse);
+  });
+
+  test('Leave{RECONNECT} performs a full reconnect', () async {
+    await container.simulateRemoteParticipantJoin('bob');
+    expect(room.remoteParticipants, hasLength(1));
+
+    final roomEvents = <RoomEvent>[];
+    final sub = room.events.listen(roomEvents.add);
+    final previousHandlers = ws.handlers;
+
+    sendLeave(lk_rtc.LeaveRequest_Action.RECONNECT, lk_models.DisconnectReason.SERVER_SHUTDOWN);
+
+    // a full reconnect re-joins, so it is answered with a JoinResponse
+    for (var i = 0; i < 200 && identical(ws.handlers, previousHandlers); i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+    expect(identical(ws.handlers, previousHandlers), isFalse, reason: 'SDK never re-opened the signal connection');
+
+    await sub();
+
+    expect(
+      roomEvents.whereType<RoomReconnectingEvent>(),
+      isNotEmpty,
+      reason: 'a RECONNECT leave must trigger a full reconnect',
+    );
+    expect(roomEvents.whereType<RoomResumingEvent>(), isEmpty);
+    expect(roomEvents.whereType<ParticipantDisconnectedEvent>(), hasLength(1));
+  });
+}

--- a/test/mock/peerconnection_mock.dart
+++ b/test/mock/peerconnection_mock.dart
@@ -285,10 +285,13 @@ a=rtpmap:32 MPV/90000
   @override
   Future<bool> removeTrack(RTCRtpSender sender) async => true;
 
+  /// Last configuration applied via [setConfiguration] (set on resume, when the
+  /// server hands out new ICE servers in the `ReconnectResponse`).
+  Map<String, dynamic>? appliedConfiguration;
+
   @override
-  Future<void> setConfiguration(Map<String, dynamic> configuration) {
-    // TODO: implement setConfiguration
-    throw UnimplementedError();
+  Future<void> setConfiguration(Map<String, dynamic> configuration) async {
+    appliedConfiguration = configuration;
   }
 
   static Future<RTCPeerConnection> create(


### PR DESCRIPTION
Fixes CLT-3322.

## Problem

When the server initiates a node migration, the SDK performs a **full reconnect** instead of a **resume**: `RoomReconnectingEvent` is emitted, every `RemoteParticipant` is torn down (one `ParticipantDisconnectedEvent` each), the client re-joins, and `RoomConnectedEvent` fires again. It should emit `RoomResumingEvent` and keep the session intact.

Reported by a customer testing `Room.sendSimulateScenario(migration: true)` on 2.12.0:

```
Room reconnecting
Participant disconnected: scanner_camera
Participant disconnected: operator_camera
Participant disconnected: additional_camera
...
Room connected: 48263580-7cfd-499d-a45c-02741ba74483
```

Migrations are routine on Cloud, so every Flutter client sees its remote participants disappear and re-join, subscriptions rebuilt, and per-participant UI state lost.

## Root cause

For a migration the server sends `LeaveRequest{Action: RESUME, Reason: MIGRATION}` (`livekit/pkg/rtc/participant.go`, `MaybeStartMigration`) and then closes the signal socket. `RESUME` means: reconnect with `reconnect=1`, keep the session.

`Engine`'s leave handler did the right thing — cleared `fullReconnectOnNext` and called `handleReconnect(ClientDisconnectReason.leaveReconnect)`. But `attemptReconnect` immediately re-set the flag:

```dart
if (_clientConfiguration?.resumeConnection == DISABLED ||
    [ClientDisconnectReason.leaveReconnect,   // <- always true for a leave-driven reconnect
     ClientDisconnectReason.negotiationFailed,
     ClientDisconnectReason.peerConnectionFailed].contains(reason)) {
  fullReconnectOnNext = true;
}
```

That list predates protocol v13 (added in #439, when a leave with `can_reconnect` could only mean a full reconnect). The v13 `RESUME` branch was ported from client-sdk-js in #574 but the escalation was never updated — so **the resume branch has been dead code ever since** and every `RESUME` leave ended up in `restartConnection()`.

Neither reference SDK behaves this way:

- **client-sdk-js** — `RTCEngine.attemptReconnect` escalates only for `resumeConnection === DISABLED` or a never-connected PeerConnection.
- **rust-sdks** — `on_session_event` routes `Action::Resume` straight into a resume cycle.

## Changes

`lib/src/core/engine.dart`:

1. Drop `leaveReconnect` from the escalation list in `attemptReconnect`. The callers that genuinely need a full reconnect — the `RECONNECT` leave branch and `connection_check/checks/checker.dart` — already set `fullReconnectOnNext = true` themselves.
2. Stop forcing `fullReconnectOnNext = false` in the `RESUME` branch. JS and Rust both treat an escalation as sticky, so a resume that already failed at the media level isn't downgraded back into a resume loop.

`test/mock/peerconnection_mock.dart`: implement `setConfiguration` (it threw `UnimplementedError`; the resume path applies the `ReconnectResponse` ICE servers to both transports).

## Tests

New `test/core/leave_action_test.dart`:

- `RESUME` (migration) → `RoomResumingEvent`, no `RoomReconnectingEvent`, no `ParticipantDisconnectedEvent`, remote participants retained, `fullReconnectOnNext` back to false.
- `RECONNECT` → `RoomReconnectingEvent` and participants dropped, as before.

Confirmed the `RESUME` test fails against the pre-fix code (times out waiting for `RoomReconnectedEvent`, because the engine re-joins instead of resuming). Full suite (409 tests), `flutter analyze`, `dart format` and `import_sorter` all clean.

## Note for app developers

`RoomResumingEvent` is the Flutter analog of JS's `SignalReconnecting`; `RoomReconnectingEvent` means a full reconnect. Both paths end in `RoomReconnectedEvent`.

## Follow-ups (not in this PR)

- A full-reconnect request arriving while a reconnect attempt is in flight is dropped: `attemptReconnect` early-returns on `_attemptingReconnect`, and the successful attempt's `_clearPendingReconnect()` cancels the queued retry, leaving `fullReconnectOnNext` stale-true (which also suppresses the next legitimate `RoomDisconnectedEvent`). JS consumes the flag at attempt start and re-dispatches in `finally`; that can't be copied verbatim here because `Room` reads `engine.fullReconnectOnNext` during the restart's join to skip fast-connect republishing.
- Flutter emits `RoomConnectedEvent` again on a full reconnect (driven off `EngineJoinResponseEvent`); JS only emits `Reconnected`. Changing that is a public-behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
