### PR TITLE
fix: fail over to other regions when Cloud rejects a connection with 403

### DIFF
--- a/lib/src/core/room.dart
+++ b/lib/src/core/room.dart
@@ -44,7 +44,6 @@ import '../support/disposable.dart';
 import '../support/http_client.dart';
 import '../support/platform.dart';
 import '../support/region_url_provider.dart';
-import '../support/websocket.dart' show WebSocketException;
 import '../track/audio_management.dart';
 import '../track/local/audio.dart';
 import '../track/local/video.dart';
@@ -367,8 +366,7 @@ class Room extends DisposableChangeNotifier with EventsEmittable<RoomEvent> {
       didConnect = true;
     } catch (e) {
       logger.warning('could not connect to $url $e');
-      if (_regionUrlProvider != null &&
-          (e is WebSocketException || (e is ConnectException && e.reason != ConnectionErrorReason.NotAllowed))) {
+      if (_regionUrlProvider != null && canFailOverToAnotherRegion(e)) {
         String? nextUrl;
         try {
           nextUrl = await _regionUrlProvider!.getNextBestRegionUrl();

--- a/lib/src/support/region_url_provider.dart
+++ b/lib/src/support/region_url_provider.dart
@@ -7,6 +7,7 @@ import '../logger.dart';
 import '../options.dart';
 import '../proto/livekit_rtc.pb.dart' as lk_models;
 import 'http_client.dart';
+import 'websocket.dart' show WebSocketException;
 
 class RegionUrlProvider {
   Uri serverUrl;
@@ -126,6 +127,33 @@ extension RegionSettingsExtension on lk_models.RegionSettings {
 
 bool isCloudUrl(Uri uri) {
   return uri.host.contains('.livekit.cloud') || uri.host.contains('.livekit.run');
+}
+
+/// Whether a failed connection attempt may be retried against a different LiveKit Cloud region.
+///
+/// LiveKit Cloud signals project-level region pinning by returning 403 on the RTC paths when the
+/// project is not allowed in the region the client geo-routed to. `/settings/regions` is
+/// deliberately left reachable so the client can discover its allowed regions and connect there,
+/// so a 403 must not be treated as terminal.
+///
+/// A 401 stays terminal: no other region will accept a token this one rejected.
+///
+/// We key on the status rather than the server's error message because that message is an
+/// unversioned human-readable string; matching it would let a copy edit break already-shipped
+/// clients. If a 403 really was a permissions failure rather than region pinning, every region
+/// attempt fails the same way and the original error still surfaces — at the cost of one extra
+/// region lookup.
+bool canFailOverToAnotherRegion(Object error) {
+  if (error is WebSocketException) {
+    return true;
+  }
+  if (error is ConnectException) {
+    if (error.reason == ConnectionErrorReason.NotAllowed) {
+      return error.statusCode == 403;
+    }
+    return true;
+  }
+  return false;
 }
 
 String toHttpUrl(String url) {

--- a/test/support/region_failover_test.dart
+++ b/test/support/region_failover_test.dart
@@ -1,0 +1,70 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:livekit_client/src/exceptions.dart';
+import 'package:livekit_client/src/support/region_url_provider.dart';
+import 'package:livekit_client/src/support/websocket.dart' show WebSocketException;
+
+void main() {
+  group('canFailOverToAnotherRegion', () {
+    test('allows failover on 403, which LiveKit Cloud uses to signal region pinning', () {
+      // The RTC paths 403 when the project is not allowed in the region the client
+      // geo-routed to. /settings/regions stays reachable so the client can discover
+      // where it is allowed to connect.
+      expect(
+        canFailOverToAnotherRegion(
+          ConnectException(
+            'project not allowed in this region.',
+            reason: ConnectionErrorReason.NotAllowed,
+            statusCode: 403,
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not allow failover on 401 — no other region will accept the same token', () {
+      expect(
+        canFailOverToAnotherRegion(
+          ConnectException(
+            'unauthorized',
+            reason: ConnectionErrorReason.NotAllowed,
+            statusCode: 401,
+          ),
+        ),
+        isFalse,
+      );
+    });
+
+    test('allows failover on a websocket error', () {
+      expect(canFailOverToAnotherRegion(const WebSocketException('failed')), isTrue);
+    });
+
+    test('allows failover on non-NotAllowed connect errors', () {
+      for (final reason in [ConnectionErrorReason.InternalError, ConnectionErrorReason.Timeout]) {
+        expect(
+          canFailOverToAnotherRegion(ConnectException('failed', reason: reason)),
+          isTrue,
+          reason: 'expected failover for $reason',
+        );
+      }
+    });
+
+    test('does not allow failover on unrelated errors', () {
+      expect(canFailOverToAnotherRegion(StateError('boom')), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Part of CLT-3325. Companion PRs: [client-sdk-js#2097](https://github.com/livekit/client-sdk-js/pull/2097), [client-sdk-swift](https://github.com/livekit/client-sdk-swift).

## Problem

LiveKit Cloud enforces project-level region pinning by returning **403 on the RTC paths** (`/rtc`, `/rtc/validate`) when a project is not allowed in the region the client geo-routed to. `/settings/regions` is deliberately excluded from that gate so the client can discover its allowed regions and connect there — per the server-side comment, *"allow other APIs to pass because clients will permanently give up if they fail."*

`Room.connect` excluded **every** `NotAllowed` error from region failover:

```dart
(e is WebSocketException || (e is ConnectException && e.reason != ConnectionErrorReason.NotAllowed))
```

and the validate handler maps any status `>= 400` to `NotAllowed` (`signal_client.dart:209-215`). So a pinned project that geo-routed to a disallowed region gave up before ever fetching the region list, and never reached the region it was allowed in.

## Fix

Extract the decision into `canFailOverToAnotherRegion` and key it on the HTTP status:

- **403 → retry other regions.** This is the region-pinning signal.
- **401 → terminal.** No other region will accept a token this one rejected.
- `WebSocketException` and non-`NotAllowed` connect errors → retry, unchanged. Unrelated error types → terminal, unchanged.

### Why status and not the error message

The server's body for this case is `"project not allowed in this region."`, but that is an unversioned human-readable string. Matching it would mean five SDKs carrying identical literals forever, and a server-side copy edit — dropping the period, rewording — would silently break already-shipped clients. That is especially bad on mobile, where a released app cannot be hot-patched.

The cost of not discriminating is bounded: if a 403 really was a permissions failure, every region attempt fails the same way and the original error still surfaces, one region lookup later. A genuinely bad token is capped tighter still — `/settings/regions` returns 401 for it, and the existing handler already rethrows on that (`room.dart:375-377`).

## Cross-SDK status

This bug is not universal. Rust and Android already fail over on any non-cancellation error and are unaffected; JS, Flutter and Swift all bail. Agents SDKs route through the Rust core, so **agents are unaffected**.

## Testing

`test/support/region_failover_test.dart` covers the predicate directly. `dart analyze` is clean on all three touched files.

**I could not execute the test suite locally** — this repo requires Dart >= 3.10.0 and the toolchain on hand is 3.9.2, so `flutter test` fails at dependency resolution before running anything. The test needs a CI run to confirm.

## Note, not fixed here

`signal_client.dart:209-215` classifies any status `>= 400` as `NotAllowed`, so 5xx responses from the validate endpoint are also treated as permission failures. That looks wrong independently of region pinning — a 5xx should probably be retryable — but it is out of scope for this change and behaviour there is unchanged.

## Open question

How often the RTC 403 actually fires for pinned projects has **not** been confirmed with the Cloud team — geo-routing may normally land clients in-region, making this an edge case (bad GeoDNS, anycast flap, VPN). The opt-in `prepareConnection()` warm-up also does region selection up front and would mask it for apps that call it. The fix is correct either way and works against today's servers, but severity is unconfirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Reviewer note (hiroshi)

Checked against the Cloud and OSS server code. The pin gate in the Cloud auth middleware matches `/rtc` and `/rtc/v1` only, and the OSS validate handler has no 403 path, so `/rtc/validate` answers 200 for a pinned project that geo-routed to a disallowed region. The 403 lands on the websocket upgrade, which Flutter already surfaces as `WebSocketException` and fails over on. This change therefore does not alter behaviour on today's Cloud. It is kept as parity with client-sdk-js#2097 and stays correct if the gate is ever widened to validate.

Follow-ups in #1204, stacked on this branch: retry every listed region instead of one, treat a 5xx or failed validate request as retryable, and stop retried attempts from emitting a disconnect that races the next attempt's cleanup.
